### PR TITLE
Fix account identifier usage in authentication docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ LOAD snowflake;
 -- 1. Create a Snowflake profile
 CREATE SECRET my_snowflake_secret (
     TYPE snowflake,
-    ACCOUNT 'your_account.snowflakecomputing.com',
+    ACCOUNT 'your_account_identifier',
     USER 'your_username',
     PASSWORD 'your_password',
     DATABASE 'your_database',
@@ -227,11 +227,15 @@ The DuckDB Snowflake extension supports multiple authentication methods:
 - **Okta**: Native Okta integration (Okta IdP only) - Implemented
 - **MFA**: Multi-factor authentication (interactive sessions only, not for programmatic use)
 
+Note on account values:
+- Use your Snowflake account identifier (e.g., `myaccount` or `xy12345.us-east-1`) for `ACCOUNT` in all secrets and connection strings (Password, Key Pair, OAuth, MFA, EXT_BROWSER, OKTA).
+- Use the full Snowflake URL (`https://<account>.snowflakecomputing.com`) only in IdP configuration such as OAuth/SAML audience values.
+
 **Quick Example (Password Auth):**
 ```sql
 CREATE SECRET my_snowflake_secret (
     TYPE snowflake,
-    ACCOUNT 'myaccount.snowflakecomputing.com',
+    ACCOUNT 'myaccount',
     USER 'myusername',
     PASSWORD 'mypassword',
     DATABASE 'mydatabase',

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -22,6 +22,7 @@ The DuckDB Snowflake extension supports multiple authentication methods to conne
 - **EXT_BROWSER uses SAML 2.0**: Works with any SAML 2.0-compliant identity provider including Okta, AD FS, Azure AD
 - **OAuth uses OAuth 2.0**: Ideal for headless environments, automation, and modern applications
 - **Browser-based methods** (EXT_BROWSER, OKTA) require interactive browser access and won't work in containerized/headless environments
+ - **Account value convention**: Use the Snowflake account identifier (e.g., `myaccount` or `xy12345.us-east-1`) for `ACCOUNT` in all secrets and connection strings (Password, Key Pair, OAuth, MFA, EXT_BROWSER, OKTA). Use the full Snowflake URL (`https://<account>.snowflakecomputing.com`) only in IdP configuration such as OAuth/SAML audience values.
 
 **Testing Status:**
 - **Tested**: PASSWORD, EXT_BROWSER, and KEY_PAIR have been fully tested and verified working
@@ -39,7 +40,7 @@ Standard username and password authentication.
 ```sql
 CREATE SECRET my_snowflake_secret (
     TYPE snowflake,
-    ACCOUNT 'myaccount.snowflakecomputing.com',
+    ACCOUNT 'myaccount',
     USER 'myusername',
     PASSWORD 'mypassword',
     DATABASE 'mydatabase',
@@ -72,7 +73,7 @@ Use **OAuth 2.0** tokens for authentication. **Recommended for Auth0/Okta enviro
 ```sql
 CREATE SECRET my_oauth_secret (
     TYPE snowflake,
-    ACCOUNT 'myaccount.snowflakecomputing.com',
+    ACCOUNT 'myaccount',
     USER 'your_user_or_client_id@clients',
     AUTH_TYPE 'oauth',
     TOKEN 'your_oauth_access_token',
@@ -180,7 +181,7 @@ Use RSA key pairs for secure, password-less authentication. This is the recommen
 ```sql
 CREATE SECRET my_keypair_secret (
     TYPE snowflake,
-    ACCOUNT 'myaccount.snowflakecomputing.com',
+    ACCOUNT 'myaccount',
     USER 'myusername',
     AUTH_TYPE 'key_pair',
     PRIVATE_KEY '/path/to/rsa_key.p8',
@@ -203,7 +204,7 @@ For enhanced security, use a passphrase-protected private key (PKCS#8 format).
 ```sql
 CREATE SECRET my_secure_keypair_secret (
     TYPE snowflake,
-    ACCOUNT 'myaccount.snowflakecomputing.com',
+    ACCOUNT 'myaccount',
     USER 'myusername',
     AUTH_TYPE 'key_pair',
     PRIVATE_KEY '/path/to/encrypted_rsa_key.p8',
@@ -250,7 +251,7 @@ Authenticate using your web browser with **SAML 2.0** identity providers (Auth0,
 ```sql
 CREATE SECRET my_sso_secret (
     TYPE snowflake,
-    ACCOUNT 'myaccount.snowflakecomputing.com',
+    ACCOUNT 'myaccount',
     DATABASE 'mydatabase',
     WAREHOUSE 'mywarehouse',
     AUTH_TYPE 'ext_browser'
@@ -337,7 +338,7 @@ Direct authentication with Okta using a custom Okta URL.
 ```sql
 CREATE SECRET my_okta_secret (
     TYPE snowflake,
-    ACCOUNT 'myaccount.snowflakecomputing.com',
+    ACCOUNT 'myaccount',
     USER 'myusername',
     AUTH_TYPE 'okta',
     OKTA_URL 'https://yourcompany.okta.com',
@@ -362,7 +363,7 @@ Authenticate using username, password, and MFA token. Provides enhanced security
 ```sql
 CREATE SECRET my_mfa_secret (
     TYPE snowflake,
-    ACCOUNT 'myaccount.snowflakecomputing.com',
+    ACCOUNT 'myaccount',
     USER 'myusername',
     PASSWORD 'mypassword',
     AUTH_TYPE 'mfa',

--- a/docs/AUTHENTICATION_SETUP.md
+++ b/docs/AUTHENTICATION_SETUP.md
@@ -10,6 +10,10 @@ This guide provides step-by-step instructions for setting up all authentication 
 
 ---
 
+Note on account values:
+- For all authentication methods (Password, Key Pair, OAuth, MFA, EXT_BROWSER, OKTA), use your Snowflake account identifier (e.g., `myaccount` or `xy12345.us-east-1`) as the `ACCOUNT` value in secrets and connection strings.
+- Use the full Snowflake URL (`https://<account>.snowflakecomputing.com`) only in IdP configuration such as OAuth/SAML audience values.
+
 ## 1. OAuth 2.0 Authentication with Auth0
 
 ### Step 1: Configure Auth0
@@ -110,7 +114,7 @@ Response:
 ```sql
 CREATE SECRET snowflake_oauth (
     TYPE snowflake,
-    ACCOUNT 'YOUR_ACCOUNT.snowflakecomputing.com',
+    ACCOUNT 'YOUR_ACCOUNT_IDENTIFIER',
     USER 'auth0|YOUR_CLIENT_ID',
     AUTH_TYPE 'oauth',
     TOKEN 'YOUR_ACCESS_TOKEN',
@@ -192,7 +196,7 @@ DESC USER YOUR_USERNAME;
 ```sql
 CREATE SECRET snowflake_keypair (
     TYPE snowflake,
-    ACCOUNT 'YOUR_ACCOUNT.snowflakecomputing.com',
+    ACCOUNT 'YOUR_ACCOUNT_IDENTIFIER',
     USER 'YOUR_USERNAME',
     AUTH_TYPE 'key_pair',
     PRIVATE_KEY '/path/to/rsa_key.p8',
@@ -210,7 +214,7 @@ SELECT * FROM sf_keypair.information_schema.tables LIMIT 5;
 ```sql
 CREATE SECRET snowflake_keypair_unencrypted (
     TYPE snowflake,
-    ACCOUNT 'YOUR_ACCOUNT.snowflakecomputing.com',
+    ACCOUNT 'YOUR_ACCOUNT_IDENTIFIER',
     USER 'YOUR_USERNAME',
     AUTH_TYPE 'key_pair',
     PRIVATE_KEY '/path/to/rsa_key_unencrypted.p8',
@@ -265,7 +269,7 @@ GRANT USAGE ON WAREHOUSE COMPUTE_WH TO ROLE PUBLIC;
 ```sql
 CREATE SECRET snowflake_okta (
     TYPE snowflake,
-    ACCOUNT 'YOUR_ACCOUNT.snowflakecomputing.com',
+    ACCOUNT 'YOUR_ACCOUNT_IDENTIFIER',
     USER 'okta_user@yourcompany.com',
     AUTH_TYPE 'okta',
     OKTA_URL 'https://yourcompany.okta.com',
@@ -328,7 +332,7 @@ GRANT USAGE ON WAREHOUSE COMPUTE_WH TO ROLE PUBLIC;
 ```sql
 CREATE SECRET snowflake_mfa (
     TYPE snowflake,
-    ACCOUNT 'YOUR_ACCOUNT.snowflakecomputing.com',
+    ACCOUNT 'YOUR_ACCOUNT_IDENTIFIER',
     USER 'mfa_user',
     PASSWORD 'SECURE_PASSWORD',
     AUTH_TYPE 'mfa',
@@ -356,7 +360,7 @@ After setting up all authentication methods, use the comprehensive test:
 
 ```bash
 # Set all required environment variables
-export SNOWFLAKE_ACCOUNT="YOUR_ACCOUNT.snowflakecomputing.com"
+export SNOWFLAKE_ACCOUNT="YOUR_ACCOUNT_IDENTIFIER"
 export SNOWFLAKE_DATABASE="YOUR_DATABASE"
 
 # Password auth (already tested)


### PR DESCRIPTION
Updates all authentication method examples to use Snowflake account identifier instead of full URL for ACCOUNT parameter. Clarifies that full URL should only be used in IdP configuration.