### PR TITLE
Fix token expiration handling (#16) and add custom endpoint support (#17)

### DIFF
--- a/src/include/snowflake_client_manager.hpp
+++ b/src/include/snowflake_client_manager.hpp
@@ -18,6 +18,12 @@ public:
 
 	void ReleaseConnection(const SnowflakeConfig &config);
 
+	//! Invalidate a connection (e.g., on auth error) and force reconnection on next GetConnection
+	void InvalidateConnection(const SnowflakeConfig &config);
+
+	//! Get a fresh connection, bypassing the cache (for retry after auth failure)
+	shared_ptr<SnowflakeClient> GetFreshConnection(const SnowflakeConfig &config);
+
 private:
 	SnowflakeClientManager() = default;
 	std::unordered_map<SnowflakeConfig, shared_ptr<SnowflakeClient>, SnowflakeConfigHash> connections;

--- a/src/include/snowflake_config.hpp
+++ b/src/include/snowflake_config.hpp
@@ -10,6 +10,9 @@ enum class SnowflakeAuthType { PASSWORD, OAUTH, KEY_PAIR, EXT_BROWSER, OKTA, MFA
 
 struct SnowflakeConfig {
 	std::string account;
+	std::string host;     // Custom host for Localstack/private endpoints
+	int32_t port = 443;   // Custom port (default: 443)
+	std::string protocol; // Custom protocol: "http" or "https" (default: https)
 	std::string warehouse;
 	std::string database;
 	std::string role;
@@ -50,6 +53,9 @@ public:
 		std::size_t seed = 0;
 
 		HashCombine(seed, config.account);
+		HashCombine(seed, config.host);
+		HashCombine(seed, config.port);
+		HashCombine(seed, config.protocol);
 		HashCombine(seed, config.warehouse);
 		HashCombine(seed, config.database);
 		HashCombine(seed, config.role);

--- a/src/include/snowflake_secret_provider.hpp
+++ b/src/include/snowflake_secret_provider.hpp
@@ -23,6 +23,9 @@ public:
 	string GetUser() const;
 	string GetPassword() const;
 	string GetAccount() const;
+	string GetHost() const;
+	int32_t GetPort() const;
+	string GetProtocol() const;
 	string GetWarehouse() const;
 	string GetDatabase() const;
 	string GetSchema() const;

--- a/src/snowflake_arrow_utils.cpp
+++ b/src/snowflake_arrow_utils.cpp
@@ -1,9 +1,21 @@
 #include "snowflake_debug.hpp"
 #include "snowflake_arrow_utils.hpp"
 #include "snowflake_query_builder.hpp"
+#include "snowflake_client_manager.hpp"
 #include "duckdb/common/exception.hpp"
 
 namespace duckdb {
+
+// Helper function to detect authentication-related errors
+// Only checks for specific Snowflake error codes to avoid false positives
+static bool IsAuthenticationError(const std::string &error_msg) {
+	// Error 390114: Authentication token has expired
+	// Error 390144: JWT token is invalid
+	// Note: We intentionally exclude 250001 (connection failed) as it's too general
+	// and can occur for network issues, not just auth failures
+	return error_msg.find("390114") != std::string::npos || // Token expired
+	       error_msg.find("390144") != std::string::npos;   // Invalid JWT
+}
 
 // Wrapper to handle ADBC ArrowArrayStream
 // This class takes ownership of an ADBC stream and makes it compatible with
@@ -124,6 +136,20 @@ unique_ptr<ArrowArrayStreamWrapper> SnowflakeProduceArrowScan(uintptr_t factory_
 				error.release(&error);
 			}
 		}
+
+		// Check if this is an authentication error (token expired, etc.)
+		if (IsAuthenticationError(error_msg)) {
+			// Invalidate the cached connection so next attempt gets a fresh one
+			auto &client_manager = snowflake::SnowflakeClientManager::GetInstance();
+			client_manager.InvalidateConnection(factory->connection->GetConfig());
+			DPRINT("Authentication error detected, connection invalidated for retry\n");
+
+			// Provide a helpful error message
+			throw IOException(error_msg +
+			                  "\n\nThe authentication token may have expired. "
+			                  "Please retry your query - a fresh connection will be established automatically.");
+		}
+
 		throw IOException(error_msg);
 	}
 

--- a/src/snowflake_arrow_utils.cpp
+++ b/src/snowflake_arrow_utils.cpp
@@ -6,14 +6,16 @@
 
 namespace duckdb {
 
-// Helper function to detect authentication-related errors
+// Helper function to detect authentication/session-related errors
 // Only checks for specific Snowflake error codes to avoid false positives
 static bool IsAuthenticationError(const std::string &error_msg) {
+	// Error 390111: Session no longer exists
 	// Error 390114: Authentication token has expired
 	// Error 390144: JWT token is invalid
 	// Note: We intentionally exclude 250001 (connection failed) as it's too general
 	// and can occur for network issues, not just auth failures
-	return error_msg.find("390114") != std::string::npos || // Token expired
+	return error_msg.find("390111") != std::string::npos || // Session no longer exists
+	       error_msg.find("390114") != std::string::npos || // Token expired
 	       error_msg.find("390144") != std::string::npos;   // Invalid JWT
 }
 

--- a/src/snowflake_client.cpp
+++ b/src/snowflake_client.cpp
@@ -185,6 +185,24 @@ void SnowflakeClient::InitializeDatabase(const SnowflakeConfig &config) {
 	status = AdbcDatabaseSetOption(&database, "adbc.snowflake.sql.account", config.account.c_str(), &error);
 	CheckError(status, "Failed to set account", &error);
 
+	// Set custom host/port/protocol for Localstack or private endpoints
+	if (!config.host.empty()) {
+		status = AdbcDatabaseSetOption(&database, "adbc.snowflake.sql.uri.host", config.host.c_str(), &error);
+		CheckError(status, "Failed to set host", &error);
+		LOG_INFO("Set custom host: %s\n", config.host.c_str());
+	}
+	if (config.port != 443) {
+		std::string port_str = std::to_string(config.port);
+		status = AdbcDatabaseSetOption(&database, "adbc.snowflake.sql.uri.port", port_str.c_str(), &error);
+		CheckError(status, "Failed to set port", &error);
+		LOG_INFO("Set custom port: %d\n", config.port);
+	}
+	if (!config.protocol.empty()) {
+		status = AdbcDatabaseSetOption(&database, "adbc.snowflake.sql.uri.protocol", config.protocol.c_str(), &error);
+		CheckError(status, "Failed to set protocol", &error);
+		LOG_INFO("Set custom protocol: %s\n", config.protocol.c_str());
+	}
+
 	// Set authentication based on type
 	switch (config.auth_type) {
 	case SnowflakeAuthType::PASSWORD:

--- a/src/snowflake_client_manager.cpp
+++ b/src/snowflake_client_manager.cpp
@@ -1,4 +1,5 @@
 #include "snowflake_client_manager.hpp"
+#include "snowflake_debug.hpp"
 
 namespace duckdb {
 namespace snowflake {
@@ -13,10 +14,18 @@ shared_ptr<SnowflakeClient> SnowflakeClientManager::GetConnection(const Snowflak
 
 	auto it = connections.find(config);
 	if (it != connections.end() && it->second->IsConnected()) {
-		return it->second;
+		// Validate the connection is still alive (handles token expiration)
+		if (it->second->TestConnection()) {
+			DPRINT("Reusing existing valid connection\n");
+			return it->second;
+		}
+		// Connection is stale (e.g., token expired), remove it
+		DPRINT("Cached connection is stale, removing and creating new connection\n");
+		connections.erase(it);
 	}
 
 	// Create new connection
+	DPRINT("Creating new Snowflake connection\n");
 	auto connection = make_shared_ptr<SnowflakeClient>();
 	connection->Connect(config);
 
@@ -27,6 +36,34 @@ shared_ptr<SnowflakeClient> SnowflakeClientManager::GetConnection(const Snowflak
 void SnowflakeClientManager::ReleaseConnection(const SnowflakeConfig &config) {
 	std::lock_guard<std::mutex> lock(connection_mutex);
 	connections.erase(config);
+}
+
+void SnowflakeClientManager::InvalidateConnection(const SnowflakeConfig &config) {
+	std::lock_guard<std::mutex> lock(connection_mutex);
+	auto it = connections.find(config);
+	if (it != connections.end()) {
+		DPRINT("Invalidating cached connection (auth error or expiration)\n");
+		connections.erase(it);
+	}
+}
+
+shared_ptr<SnowflakeClient> SnowflakeClientManager::GetFreshConnection(const SnowflakeConfig &config) {
+	std::lock_guard<std::mutex> lock(connection_mutex);
+
+	// Remove any existing connection
+	auto it = connections.find(config);
+	if (it != connections.end()) {
+		DPRINT("Removing existing connection to create fresh one\n");
+		connections.erase(it);
+	}
+
+	// Create new connection
+	DPRINT("Creating fresh Snowflake connection\n");
+	auto connection = make_shared_ptr<SnowflakeClient>();
+	connection->Connect(config);
+
+	connections[config] = connection;
+	return connection;
 }
 
 } // namespace snowflake

--- a/src/snowflake_config.cpp
+++ b/src/snowflake_config.cpp
@@ -22,6 +22,12 @@ SnowflakeConfig SnowflakeConfig::ParseConnectionString(const std::string &connec
 
 		if (key == "account") {
 			config.account = value;
+		} else if (key == "host") {
+			config.host = value;
+		} else if (key == "port") {
+			config.port = std::stoi(value);
+		} else if (key == "protocol") {
+			config.protocol = value;
 		} else if (key == "username" || key == "user") {
 			config.username = value;
 		} else if (key == "password") {
@@ -78,6 +84,15 @@ SnowflakeConfig SnowflakeConfig::ParseConnectionString(const std::string &connec
 std::string SnowflakeConfig::ToString() const {
 	std::ostringstream oss;
 	oss << "account=" << account << ";";
+	if (!host.empty()) {
+		oss << "host=" << host << ";";
+	}
+	if (port != 443) {
+		oss << "port=" << port << ";";
+	}
+	if (!protocol.empty()) {
+		oss << "protocol=" << protocol << ";";
+	}
 	oss << "user=" << username << ";";
 	oss << "password=" << password << ";";
 	oss << "database=" << database << ";";
@@ -113,9 +128,10 @@ std::string SnowflakeConfig::ToString() const {
 }
 
 bool SnowflakeConfig::operator==(const SnowflakeConfig &other) const {
-	return (account == other.account && username == other.username && password == other.password &&
-	        warehouse == other.warehouse && database == other.database && role == other.role &&
-	        auth_type == other.auth_type && oauth_token == other.oauth_token && private_key == other.private_key &&
+	return (account == other.account && host == other.host && port == other.port && protocol == other.protocol &&
+	        username == other.username && password == other.password && warehouse == other.warehouse &&
+	        database == other.database && role == other.role && auth_type == other.auth_type &&
+	        oauth_token == other.oauth_token && private_key == other.private_key &&
 	        private_key_passphrase == other.private_key_passphrase && okta_url == other.okta_url &&
 	        query_timeout == other.query_timeout && keep_alive == other.keep_alive);
 }

--- a/src/snowflake_secret_provider.cpp
+++ b/src/snowflake_secret_provider.cpp
@@ -30,6 +30,30 @@ string SnowflakeSecret::GetAccount() const {
 	return "";
 }
 
+string SnowflakeSecret::GetHost() const {
+	Value value;
+	if (TryGetValue("host", value)) {
+		return value.GetValue<string>();
+	}
+	return "";
+}
+
+int32_t SnowflakeSecret::GetPort() const {
+	Value value;
+	if (TryGetValue("port", value)) {
+		return value.GetValue<int32_t>();
+	}
+	return 443; // Default HTTPS port
+}
+
+string SnowflakeSecret::GetProtocol() const {
+	Value value;
+	if (TryGetValue("protocol", value)) {
+		return value.GetValue<string>();
+	}
+	return ""; // Empty means use default (https)
+}
+
 string SnowflakeSecret::GetWarehouse() const {
 	Value value;
 	if (TryGetValue("warehouse", value)) {
@@ -161,9 +185,9 @@ unique_ptr<BaseSecret> CreateSnowflakeSecret(ClientContext &context, CreateSecre
 	vector<string> required_fields = {"account", "database"};
 
 	// All possible optional fields
-	vector<string> optional_fields = {"user",        "password", "warehouse", "schema",
-	                                  "auth_type",   "token",    "okta_url",  "private_key_passphrase",
-	                                  "private_key", "role"};
+	vector<string> optional_fields = {
+	    "user",        "password", "warehouse", "schema", "auth_type", "token", "okta_url", "private_key_passphrase",
+	    "private_key", "role",     "host",      "port",   "protocol"};
 
 	// Process required fields
 	for (const auto &field : required_fields) {
@@ -217,6 +241,11 @@ void RegisterSnowflakeSecretType(DatabaseInstance &instance) {
 	create_function.named_parameters["database"] = LogicalType::VARCHAR;
 	create_function.named_parameters["schema"] = LogicalType::VARCHAR;
 	create_function.named_parameters["role"] = LogicalType::VARCHAR;
+
+	// Network configuration parameters (for Localstack/private endpoints)
+	create_function.named_parameters["host"] = LogicalType::VARCHAR;
+	create_function.named_parameters["port"] = LogicalType::INTEGER;
+	create_function.named_parameters["protocol"] = LogicalType::VARCHAR;
 
 	// OAuth/Okta/Key Pair authentication parameters
 	create_function.named_parameters["auth_type"] = LogicalType::VARCHAR;

--- a/src/snowflake_secrets.cpp
+++ b/src/snowflake_secrets.cpp
@@ -70,6 +70,9 @@ snowflake::SnowflakeConfig SnowflakeSecretsHelper::GetCredentials(ClientContext 
 		config.username = snowflake_secret->GetUser();
 		config.password = snowflake_secret->GetPassword();
 		config.account = snowflake_secret->GetAccount();
+		config.host = snowflake_secret->GetHost();
+		config.port = snowflake_secret->GetPort();
+		config.protocol = snowflake_secret->GetProtocol();
 		config.warehouse = snowflake_secret->GetWarehouse();
 		config.database = snowflake_secret->GetDatabase();
 		config.role = snowflake_secret->GetRole();


### PR DESCRIPTION
## Summary

This PR addresses two related connection management issues:

### Issue #16 - Token Expiration Handling
- Validate cached connections with TestConnection() before reuse
- Detect auth errors (390114: token expired, 390144: invalid JWT) during query
- Invalidate stale connections automatically for transparent retry

### Issue #17 - Custom Endpoint Support (Localstack)
- Add host, port, and protocol parameters to secrets
- Pass to ADBC driver via adbc.snowflake.sql.uri.host/port/protocol
- Enables connection to Localstack or private Snowflake endpoints

## Usage (Issue #17)

```sql
CREATE SECRET localstack_sf (
    TYPE snowflake,
    ACCOUNT 'test',
    HOST 'snowflake.localhost.localstack.cloud',
    PORT 4566,
    PROTOCOL 'http',
    USER 'test',
    PASSWORD 'test',
    DATABASE 'test_db'
);
```

## Testing
- Build: Verified
- Format: Passed
- Issue #16: Unit tested error detection patterns
- Issue #17: Requires Localstack Pro for full integration test

Closes #16
Closes #17