### PR TITLE
Fix Issue #26 (PEM parsing regression) and Issue #21 (snowflake_query segfault)

### DIFF
--- a/src/include/snowflake_arrow_utils.hpp
+++ b/src/include/snowflake_arrow_utils.hpp
@@ -29,6 +29,11 @@ struct SnowflakeArrowStreamFactory {
 	AdbcStatement statement;
 	bool statement_initialized = false;
 
+	// Pre-executed Arrow stream from bind time (used by snowflake_query to avoid
+	// double-executing the query: once for schema in bind, once for data in scan)
+	struct ArrowArrayStream cached_stream;
+	bool has_cached_stream = false;
+
 	// Pushdown configuration
 	bool filter_pushdown_enabled = false;
 	bool projection_pushdown_enabled = false;
@@ -41,6 +46,7 @@ struct SnowflakeArrowStreamFactory {
 	SnowflakeArrowStreamFactory(shared_ptr<snowflake::SnowflakeClient> conn, const std::string &query_str)
 	    : connection(std::move(conn)), query(query_str), modified_query(query_str) {
 		std::memset(&statement, 0, sizeof(statement));
+		std::memset(&cached_stream, 0, sizeof(cached_stream));
 	}
 
 	~SnowflakeArrowStreamFactory() {
@@ -48,6 +54,10 @@ struct SnowflakeArrowStreamFactory {
 		if (statement_initialized) {
 			AdbcError error;
 			AdbcStatementRelease(&statement, &error);
+		}
+		// Release cached stream if present
+		if (has_cached_stream && cached_stream.release) {
+			cached_stream.release(&cached_stream);
 		}
 	}
 
@@ -73,5 +83,11 @@ unique_ptr<ArrowArrayStreamWrapper> SnowflakeProduceArrowScan(uintptr_t factory_
 //   ArrowArrayStream* schema: Output parameter that will be filled with the
 //   Arrow schema
 void SnowflakeGetArrowSchema(ArrowArrayStream *factory_ptr, ArrowSchema &schema);
+
+// Execute the query and cache the resulting Arrow stream in the factory.
+// Also populates schema from the stream's get_schema callback.
+// Used by snowflake_query bind to avoid double-execution: the cached stream is
+// returned by SnowflakeProduceArrowScan instead of re-executing the query.
+void SnowflakeExecuteAndCacheStream(SnowflakeArrowStreamFactory *factory, ArrowSchema &schema);
 
 } // namespace duckdb

--- a/src/snowflake_arrow_utils.cpp
+++ b/src/snowflake_arrow_utils.cpp
@@ -43,6 +43,15 @@ public:
 unique_ptr<ArrowArrayStreamWrapper> SnowflakeProduceArrowScan(uintptr_t factory_ptr,
                                                               ArrowStreamParameters &parameters) {
 	auto factory = reinterpret_cast<SnowflakeArrowStreamFactory *>(factory_ptr);
+
+	// If the query was pre-executed at bind time (snowflake_query path), return
+	// the cached stream directly without re-executing.
+	if (factory->has_cached_stream) {
+		auto wrapper = make_uniq<SnowflakeArrowArrayStreamWrapper>();
+		wrapper->InitializeFromADBC(&factory->cached_stream);
+		factory->has_cached_stream = false;
+		return std::move(wrapper);
+	}
 	DPRINT("SnowflakeProduceArrowScan: factory=%p, statement_initialized=%d\n", (void *)factory,
 	       factory->statement_initialized);
 	DPRINT("SnowflakeProduceArrowScan: pushdown enabled: filter=%d, projection=%d\n", factory->filter_pushdown_enabled,
@@ -211,6 +220,57 @@ void SnowflakeGetArrowSchema(ArrowArrayStream *factory_ptr, ArrowSchema &schema)
 			}
 		}
 		throw IOException(error_msg);
+	}
+}
+
+void SnowflakeExecuteAndCacheStream(SnowflakeArrowStreamFactory *factory, ArrowSchema &schema) {
+	AdbcError error;
+	std::memset(&error, 0, sizeof(error));
+	AdbcStatusCode status = AdbcStatementNew(factory->connection->GetConnection(), &factory->statement, &error);
+	if (status != ADBC_STATUS_OK) {
+		throw IOException("Failed to create statement for snowflake_query");
+	}
+	factory->statement_initialized = true;
+
+	status = AdbcStatementSetSqlQuery(&factory->statement, factory->modified_query.c_str(), &error);
+	if (status != ADBC_STATUS_OK) {
+		std::string msg = "Failed to set query: ";
+		if (error.message) {
+			msg += error.message;
+			if (error.release)
+				error.release(&error);
+		}
+		throw IOException(msg);
+	}
+
+	int64_t rows_affected;
+	AdbcError exec_error;
+	std::memset(&exec_error, 0, sizeof(exec_error));
+	status = AdbcStatementExecuteQuery(&factory->statement, &factory->cached_stream, &rows_affected, &exec_error);
+	if (status != ADBC_STATUS_OK) {
+		std::string msg = "Failed to execute snowflake_query: ";
+		if (exec_error.message) {
+			msg += exec_error.message;
+			if (exec_error.release)
+				exec_error.release(&exec_error);
+		}
+		if (IsAuthenticationError(msg)) {
+			auto &client_manager = snowflake::SnowflakeClientManager::GetInstance();
+			client_manager.InvalidateConnection(factory->connection->GetConfig());
+			DPRINT("Authentication error detected, connection invalidated for retry\n");
+			throw IOException(msg + "\n\nThe authentication token may have expired. "
+			                        "Please retry your query - a fresh connection will be established automatically.");
+		}
+		throw IOException(msg);
+	}
+	factory->has_cached_stream = true;
+
+	std::memset(&schema, 0, sizeof(schema));
+	if (factory->cached_stream.get_schema) {
+		int rc = factory->cached_stream.get_schema(&factory->cached_stream, &schema);
+		if (rc != 0) {
+			throw IOException("Failed to get schema from snowflake_query stream");
+		}
 	}
 }
 

--- a/src/snowflake_client.cpp
+++ b/src/snowflake_client.cpp
@@ -263,7 +263,21 @@ void SnowflakeClient::InitializeDatabase(const SnowflakeConfig &config) {
 			buffer << key_file.rdbuf();
 			private_key_content = buffer.str();
 		} else if (!config.private_key.empty()) {
-			private_key_content = config.private_key;
+			// Backward compatibility with v1.4.3: auto-detect if this is a file path
+			// In v1.4.3, users could pass either a file path or key content to private_key
+			// and the code would auto-detect based on FileExists()
+			if (FileExists(config.private_key)) {
+				std::ifstream key_file(config.private_key);
+				if (!key_file.is_open()) {
+					throw IOException("Failed to open private key file: " + config.private_key);
+				}
+				std::stringstream buffer;
+				buffer << key_file.rdbuf();
+				private_key_content = buffer.str();
+			} else {
+				// Assume it's the key content directly
+				private_key_content = config.private_key;
+			}
 		}
 
 		if (!private_key_content.empty()) {

--- a/src/snowflake_scan.cpp
+++ b/src/snowflake_scan.cpp
@@ -57,10 +57,11 @@ static unique_ptr<FunctionData> SnowflakeScanBind(ClientContext &context, TableF
 	bind_data->factory->filter_pushdown_enabled = false;
 	bind_data->factory->projection_pushdown_enabled = false;
 
-	// Get the schema from Snowflake using ADBC's ExecuteSchema
-	// This executes the query with schema-only mode to get column information
-	SnowflakeGetArrowSchema(reinterpret_cast<ArrowArrayStream *>(bind_data->factory.get()),
-	                        bind_data->schema_root.arrow_schema);
+	// Execute the full query now and cache the stream. This is necessary because
+	// SnowflakeGetArrowSchema (ExecuteSchema) leaves the ADBC driver in a state
+	// where a second statement cannot be created on the same connection, causing
+	// a segfault (SIGSEGV) when SnowflakeProduceArrowScan runs.
+	SnowflakeExecuteAndCacheStream(bind_data->factory.get(), bind_data->schema_root.arrow_schema);
 
 	// Use DuckDB's Arrow integration to populate the table type information
 	// This converts Arrow schema to DuckDB types and handles all type mappings

--- a/test/sql/snowflake_query_ddl.test
+++ b/test/sql/snowflake_query_ddl.test
@@ -1,0 +1,49 @@
+# name: test/sql/snowflake_query_ddl.test
+# description: Test snowflake_query with non-SELECT statements (DESC TABLE, SHOW, etc.)
+# group: [sql]
+
+#              Regression test for segfault caused by AdbcStatementExecuteSchema consuming
+#              the ADBC statement for DDL/metadata commands, leaving nothing for ProduceArrowScan.
+
+require snowflake
+
+# Require environment variables to be set
+require-env SNOWFLAKE_ACCOUNT
+
+require-env SNOWFLAKE_USERNAME
+
+require-env SNOWFLAKE_PASSWORD
+
+require-env SNOWFLAKE_DATABASE
+
+statement ok
+LOAD snowflake;
+
+# Create a secret for snowflake_query to use
+statement ok
+CREATE SECRET sf_secret (
+    TYPE snowflake,
+    ACCOUNT '${SNOWFLAKE_ACCOUNT}',
+    USER '${SNOWFLAKE_USERNAME}',
+    PASSWORD '${SNOWFLAKE_PASSWORD}',
+    DATABASE '${SNOWFLAKE_DATABASE}'
+);
+
+# Test 1: DESC TABLE via snowflake_query must not segfault and must return rows
+# This is a regression test: previously snowflake_query crashed with SIGSEGV
+# for non-SELECT statements because AdbcStatementExecuteSchema eagerly executed
+# DDL commands, consuming the ADBC statement before ProduceArrowScan could use it.
+query I
+SELECT COUNT(*) > 0 FROM snowflake_query('DESC TABLE ${SNOWFLAKE_DATABASE}.TPCH_SF1.CUSTOMER', 'sf_secret');
+----
+true
+
+# Test 2: SELECT query still works correctly after the fix
+query I
+SELECT COUNT(*) FROM snowflake_query('SELECT C_CUSTKEY FROM ${SNOWFLAKE_DATABASE}.TPCH_SF1.CUSTOMER LIMIT 5', 'sf_secret');
+----
+5
+
+# Cleanup
+statement ok
+DROP SECRET IF EXISTS sf_secret;


### PR DESCRIPTION
## Summary

This PR fixes two bugs introduced in the v1.5 update:

1. **Issue #26**: Key pair authentication fails with "Failed to parse PEM block" when using `PRIVATE_KEY` parameter with a file path
2. **Issue #21**: `snowflake_query()` crashes with SIGSEGV when executing DDL statements like `DESC TABLE` or `SHOW TABLES`

## Issue #26: PEM Parsing Regression

### Root Cause
The v1.5 refactoring introduced separate `private_key` (content) and `private_key_file` (path) parameters, but removed the `FileExists()` auto-detection that existed in v1.4.3. Users upgrading from v1.4.3 who used `PRIVATE_KEY '/path/to/key.pem'` would have the file path treated as key content, causing the ADBC driver to fail parsing.

### Fix
Restore backward compatibility by auto-detecting file paths in the `private_key` parameter:
- If `FileExists(config.private_key)` is true, read file content
- Otherwise, treat as inline key content

Both syntaxes now work:
```sql
-- Old v1.4.3 syntax (auto-detected as file path)
PRIVATE_KEY '/path/to/key.pem'

-- New v1.5 syntax (explicit)
PRIVATE_KEY_FILE '/path/to/key.pem'
```

## Issue #21: snowflake_query Segfault on DDL

### Root Cause
`AdbcStatementExecuteSchema()` fully executes DDL/metadata commands (like `DESC TABLE`, `SHOW TABLES`) instead of doing a schema-only dry run. This consumes the Arrow stream, so when `SnowflakeProduceArrowScan()` later calls `AdbcStatementExecuteQuery()`, the statement is in an invalid state, causing SIGSEGV.

### Fix
Introduce `SnowflakeExecuteAndCacheStream()` that:
1. Executes the query at bind time
2. Caches the `ArrowArrayStream` in the factory
3. Returns the cached stream in `ProduceArrowScan` instead of re-executing

## Test Results

| Test | Result |
|------|--------|
| `PRIVATE_KEY '/path/to/key.pem'` (old syntax) | Pass |
| `PRIVATE_KEY_FILE '/path/to/key.pem'` (new syntax) | Pass |
| `DESC TABLE ...` via snowflake_query | Pass |
| `SHOW TABLES ...` via snowflake_query | Pass |
| Unit tests | All pass |

## Files Changed

- `src/snowflake_client.cpp` - Restore FileExists() auto-detection for backward compat
- `src/include/snowflake_arrow_utils.hpp` - Add cached_stream fields to factory
- `src/snowflake_arrow_utils.cpp` - Implement SnowflakeExecuteAndCacheStream()
- `src/snowflake_scan.cpp` - Use cached stream for snowflake_query bind
- `test/sql/snowflake_query_ddl.test` - Regression test for DDL statements

Closes #26
Closes #21