### PR TITLE
Fix OAuth token not reaching Snowflake ADBC driver

### DIFF
--- a/src/snowflake_client.cpp
+++ b/src/snowflake_client.cpp
@@ -231,7 +231,7 @@ void SnowflakeClient::InitializeDatabase(const SnowflakeConfig &config) {
 		if (!config.oauth_token.empty()) {
 			LOG_DEBUG("Setting token (length: %zu)\n", config.oauth_token.length());
 			status =
-			    AdbcDatabaseSetOption(&database, "adbc.snowflake.sql.auth_token", config.oauth_token.c_str(), &error);
+			    AdbcDatabaseSetOption(&database, "adbc.snowflake.sql.client_option.auth_token", config.oauth_token.c_str(), &error);
 			CheckError(status, "Failed to set OAuth token", &error);
 			LOG_DEBUG("Token set successfully\n");
 		}


### PR DESCRIPTION
## Summary
- Fix ADBC option key for OAuth token: adbc.snowflake.sql.auth_token → adbc.snowflake.sql.client_option.auth_token

## Problem

OAuth authentication always failed with `390303: Invalid OAuth access token`, even with a valid token. The token was never actually reaching the Go ADBC driver because the option key was wrong.

The C++ extension was setting: `adbc.snowflake.sql.auth_token` but the ADBC Snowflake driver expects `adbc.snowflake.sql.client_option.auth_token`.
[adbc-drivers/snowflake: go/driver.go](https://github.com/adbc-drivers/snowflake/blob/36e948f786303408a5e40c0c309c976a2f4da915/go/driver.go#L95):
```
OptionAuthToken = "adbc.snowflake.sql.client_option.auth_token"
```

Because the key didn't match, the Go driver silently ignored it, connecting with an empty token. Snowflake then reported it as "invalid" (malformed).

## Fix
Single-line change in `src/snowflake_client.cpp` — use the correct option key with the `client_option` segment.