### PR TITLE
fix: pass password to ADBC driver for Okta native authentication

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -331,9 +331,9 @@ SELECT SYSTEM$SHOW_SAML_IDP_METADATA('auth0_saml');
 
 ## 5. Native Okta Authentication
 
-Direct authentication with Okta using a custom Okta URL.
+Direct authentication with Okta using username, password, and a custom Okta URL. The ADBC driver's `auth_okta` mode sends credentials directly to Okta's native authentication API — no browser interaction is required.
 
-**Important**: This authentication method only works if your organization uses **Okta** as the identity provider. It is **not compatible with Auth0**. If you are using Auth0, use **EXT_BROWSER** (SAML 2.0) authentication instead.
+**Important**: This authentication method only works if your organization uses **Okta** as the identity provider and has [Native SSO — Okta](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use#native-sso-okta-only) configured for Snowflake. It is **not compatible with Auth0**. If you are using Auth0, use **EXT_BROWSER** (SAML 2.0) authentication instead.
 
 ```sql
 CREATE SECRET my_okta_secret (
@@ -341,6 +341,7 @@ CREATE SECRET my_okta_secret (
     ACCOUNT 'myaccount',
     USER 'myusername',
     AUTH_TYPE 'okta',
+    PASSWORD 'mypassword',
     OKTA_URL 'https://yourcompany.okta.com',
     DATABASE 'mydatabase',
     WAREHOUSE 'mywarehouse'
@@ -349,7 +350,7 @@ CREATE SECRET my_okta_secret (
 
 **Connection String:**
 ```
-account=myaccount;user=myusername;auth_type=okta;okta_url=https://yourcompany.okta.com;database=mydb;warehouse=mywh
+account=myaccount;user=myusername;password=mypassword;auth_type=okta;okta_url=https://yourcompany.okta.com;database=mydb;warehouse=mywh
 ```
 
 ## 6. Multi-Factor Authentication (MFA)

--- a/docs/AUTHENTICATION_SETUP.md
+++ b/docs/AUTHENTICATION_SETUP.md
@@ -264,7 +264,7 @@ GRANT USAGE ON WAREHOUSE COMPUTE_WH TO ROLE PUBLIC;
 
 ### Step 3: Test in DuckDB
 
-**Note**: Native Okta authentication requires browser interaction for SSO.
+**Note**: Native Okta authentication sends username and password directly to Okta's native API — no browser interaction is required. This is distinct from External Browser (SAML 2.0) SSO.
 
 ```sql
 CREATE SECRET snowflake_okta (
@@ -272,12 +272,13 @@ CREATE SECRET snowflake_okta (
     ACCOUNT 'YOUR_ACCOUNT_IDENTIFIER',
     USER 'okta_user@yourcompany.com',
     AUTH_TYPE 'okta',
+    PASSWORD 'your_okta_password',
     OKTA_URL 'https://yourcompany.okta.com',
     DATABASE 'YOUR_DATABASE',
     WAREHOUSE 'COMPUTE_WH'
 );
 
--- This will open a browser window for Okta authentication
+-- Authenticates directly with Okta (no browser needed)
 ATTACH '' AS sf_okta (TYPE snowflake, SECRET snowflake_okta, READ_ONLY);
 SELECT * FROM sf_okta.information_schema.tables LIMIT 5;
 ```
@@ -286,6 +287,7 @@ SELECT * FROM sf_okta.information_schema.tables LIMIT 5;
 
 ```bash
 export SNOWFLAKE_OKTA_USER="okta_user@yourcompany.com"
+export SNOWFLAKE_OKTA_PASSWORD="your_okta_password"
 export SNOWFLAKE_OKTA_URL="https://yourcompany.okta.com"
 ```
 
@@ -378,6 +380,7 @@ export SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="YOUR_PASSPHRASE"
 
 # Okta
 export SNOWFLAKE_OKTA_USER="okta_user@yourcompany.com"
+export SNOWFLAKE_OKTA_PASSWORD="your_okta_password"
 export SNOWFLAKE_OKTA_URL="https://yourcompany.okta.com"
 
 # MFA

--- a/src/snowflake_client.cpp
+++ b/src/snowflake_client.cpp
@@ -317,6 +317,10 @@ void SnowflakeClient::InitializeDatabase(const SnowflakeConfig &config) {
 			                               config.okta_url.c_str(), &error);
 			CheckError(status, "Failed to set Okta URL", &error);
 		}
+		if (!config.password.empty()) {
+			status = AdbcDatabaseSetOption(&database, "password", config.password.c_str(), &error);
+			CheckError(status, "Failed to set password for Okta", &error);
+		}
 		break;
 	case SnowflakeAuthType::MFA:
 		if (!config.username.empty()) {

--- a/src/snowflake_secrets.cpp
+++ b/src/snowflake_secrets.cpp
@@ -122,6 +122,9 @@ snowflake::SnowflakeConfig SnowflakeSecretsHelper::GetCredentials(ClientContext 
 		} else if (StringUtil::CIEquals(auth_type_str, "okta")) {
 			config.auth_type = snowflake::SnowflakeAuthType::OKTA;
 			config.okta_url = GetSecretString(*kv_secret, "okta_url");
+			// Okta native auth needs the password forwarded to ADBC; without
+			// it the Snowflake Go driver fails with "password is empty".
+			config.password = GetSecretString(*kv_secret, "password");
 		} else if (StringUtil::CIEquals(auth_type_str, "mfa")) {
 			config.auth_type = snowflake::SnowflakeAuthType::MFA;
 		} else {

--- a/test/sql/snowflake_all_auth_methods.test
+++ b/test/sql/snowflake_all_auth_methods.test
@@ -233,14 +233,19 @@ LIMIT 1000
 
 require-env SNOWFLAKE_OKTA_USER
 
+require-env SNOWFLAKE_OKTA_PASSWORD
+
 require-env SNOWFLAKE_OKTA_URL
 
 # Test 27: Create Okta Secret
+# Note: PASSWORD is required for native Okta auth — the ADBC driver's auth_okta
+# mode sends username+password to Okta's native authentication API.
 statement ok
 CREATE PERSISTENT SECRET IF NOT EXISTS sf_okta_secret (
     TYPE snowflake,
     ACCOUNT '${SNOWFLAKE_ACCOUNT}',
     USER '${SNOWFLAKE_OKTA_USER}',
+    PASSWORD '${SNOWFLAKE_OKTA_PASSWORD}',
     AUTH_TYPE 'okta',
     OKTA_URL '${SNOWFLAKE_OKTA_URL}',
     DATABASE '${SNOWFLAKE_DATABASE}',


### PR DESCRIPTION
## Problem

Okta native authentication (`AUTH_TYPE 'okta'`) fails with `password is empty` from the Snowflake ADBC Go driver.

The ADBC driver's `auth_okta` mode authenticates by sending username + password directly to Okta's native API. However, the extension never extracts the password from the secret nor passes it to the ADBC driver when using Okta auth.

## Root Cause

Two places were missing password handling for the Okta auth type:

1. **`snowflake_secrets.cpp`** — `GetCredentials()` extracts `okta_url` in the OKTA branch but does not extract `password`, even though the MFA branch right below it does.
2. **`snowflake_client.cpp`** — `InitializeDatabase()` sets the Okta URL and auth type but never calls `AdbcDatabaseSetOption` for `"password"`, even though the MFA case right below it does.

## Fix

- Extract password from the secret in the OKTA branch of `GetCredentials`
- Pass password to `AdbcDatabaseSetOption` in the OKTA case of `InitializeDatabase`
- Update the Okta test in `snowflake_all_auth_methods.test` to include the required `PASSWORD` parameter

## Testing

Tested against a live Snowflake instance using Okta native authentication (Okta as IdP). Before this fix, `ATTACH` fails with `password is empty`. After this fix, queries succeed.