### PR TITLE
fix: use correct ADBC key for database and make DATABASE optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ CREATE SECRET my_snowflake_secret (
     ACCOUNT 'your_account_identifier',
     USER 'your_username',
     PASSWORD 'your_password',
-    DATABASE 'your_database',
-    WAREHOUSE 'your_warehouse'
+    DATABASE 'your_database',      -- Optional: default database
+    WAREHOUSE 'your_warehouse'     -- Optional: default warehouse
 );
 
 -- 2.1 Query Snowflake data using pass through query
@@ -257,9 +257,9 @@ CREATE SECRET my_snowflake_secret (
     ACCOUNT 'myaccountidentifier',
     USER 'myusername',
     PASSWORD 'mypassword',
-    DATABASE 'mydatabase',
-    WAREHOUSE 'mywarehouse',
-    SCHEMA 'myschema'  -- Optional: default schema
+    DATABASE 'mydatabase',          -- Optional: default database
+    WAREHOUSE 'mywarehouse',        -- Optional: default warehouse
+    SCHEMA 'myschema'               -- Optional: default schema
 );
 ```
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -37,6 +37,8 @@ The DuckDB Snowflake extension supports multiple authentication methods to conne
 
 Standard username and password authentication.
 
+> **Required parameters**: `ACCOUNT`, `USER`. All other parameters (`DATABASE`, `WAREHOUSE`, `SCHEMA`, etc.) are optional. When `DATABASE` is omitted, use fully qualified table names (e.g., `mydb.myschema.mytable`).
+
 ```sql
 CREATE SECRET my_snowflake_secret (
     TYPE snowflake,

--- a/src/snowflake_client.cpp
+++ b/src/snowflake_client.cpp
@@ -339,7 +339,7 @@ void SnowflakeClient::InitializeDatabase(const SnowflakeConfig &config) {
 	}
 
 	if (!config.database.empty()) {
-		status = AdbcDatabaseSetOption(&database, "adbc.snowflake.sql.database", config.database.c_str(), &error);
+		status = AdbcDatabaseSetOption(&database, "adbc.snowflake.sql.db", config.database.c_str(), &error);
 		CheckError(status, "Failed to set database", &error);
 	}
 

--- a/src/snowflake_secret_provider.cpp
+++ b/src/snowflake_secret_provider.cpp
@@ -147,7 +147,7 @@ static bool TryGetValueCaseInsensitive(const SnowflakeSecret &secret, const stri
 //! Validate that all required fields are present
 void SnowflakeSecret::Validate() const {
 	// Always required fields
-	vector<string> always_required = {"user", "account", "database"};
+	vector<string> always_required = {"user", "account"};
 	vector<string> missing_fields;
 
 	for (const auto &field : always_required) {
@@ -236,7 +236,7 @@ unique_ptr<BaseSecret> CreateSnowflakeSecret(ClientContext &context, CreateSecre
 
 	// Extract Snowflake-specific parameters from the input options
 	// Always required fields
-	vector<string> always_required = {"user", "account", "database"};
+	vector<string> always_required = {"user", "account"};
 	// Conditionally required (password OR private_key/private_key_file based on auth_type)
 	vector<string> auth_fields = {"password",  "private_key", "private_key_file", "private_key_password",
 	                              "auth_type", "token",       "okta_url"};
@@ -247,8 +247,10 @@ unique_ptr<BaseSecret> CreateSnowflakeSecret(ClientContext &context, CreateSecre
 	    FindOptionCaseInsensitive(input.options, "private_key_password") == input.options.end()) {
 		secret->secret_map["private_key_password"] = passphrase_it->second;
 	}
-	// Optional fields
-	vector<string> optional_fields = {"warehouse", "schema", "role", "host", "port", "protocol"};
+	// Optional fields. database is here (not always_required) so that secrets
+	// can be created without a default database and rely on fully-qualified
+	// table names — but a provided database is still persisted into secret_map.
+	vector<string> optional_fields = {"database", "warehouse", "schema", "role", "host", "port", "protocol"};
 
 	// Process always required fields
 	for (const auto &field : always_required) {

--- a/test/sql/snowflake_basic_connectivity.test
+++ b/test/sql/snowflake_basic_connectivity.test
@@ -173,16 +173,15 @@ CREATE PERSISTENT SECRET missing_auth (
 ----
 Snowflake secret requires 'password' field
 
-# Test 17: Create Secret with Missing Database (should fail)
-statement error
+# Test 17: DATABASE is optional — secrets without one are valid and must rely
+# on fully-qualified table names. See PR #35 / snowflake_database_parameter.test.
+statement ok
 CREATE PERSISTENT SECRET missing_database (
     TYPE snowflake,
     ACCOUNT 'test_account',
     USER 'test_user',
     PASSWORD 'test_pass'
 )
-----
-Snowflake secret requires field 'database'
 
 # Test 18: Create Secret with Invalid Type (should fail)
 statement error
@@ -229,6 +228,9 @@ DROP SECRET IF EXISTS snowflake_minimal
 
 statement ok
 DROP SECRET IF EXISTS snowflake_full
+
+statement ok
+DROP SECRET IF EXISTS missing_database
 
 statement ok
 DROP SECRET IF EXISTS duplicate_test

--- a/test/sql/snowflake_database_parameter.test
+++ b/test/sql/snowflake_database_parameter.test
@@ -1,0 +1,65 @@
+# name: test/sql/snowflake_database_parameter.test
+# description: Test that the DATABASE parameter is optional when creating Snowflake secrets
+# group: [sql]
+
+require snowflake
+
+# Test 1: Creating a secret without DATABASE should succeed
+# DATABASE was previously in the always_required list, causing this to fail
+# with "Missing required field: database"
+statement ok
+CREATE SECRET sf_no_db_secret (
+    TYPE snowflake,
+    ACCOUNT 'test_account',
+    USER 'test_user',
+    PASSWORD 'test_password'
+)
+
+# Test 2: Verify the secret was created
+query T
+SELECT name FROM duckdb_secrets() WHERE name = 'sf_no_db_secret'
+----
+sf_no_db_secret
+
+# Test 3: Creating a secret with DATABASE should still work
+statement ok
+CREATE SECRET sf_with_db_secret (
+    TYPE snowflake,
+    ACCOUNT 'test_account',
+    USER 'test_user',
+    PASSWORD 'test_password',
+    DATABASE 'my_database'
+)
+
+# Test 4: Verify the secret was created
+query T
+SELECT name FROM duckdb_secrets() WHERE name = 'sf_with_db_secret'
+----
+sf_with_db_secret
+
+# Test 5: USER and ACCOUNT are still required - missing USER should fail
+statement error
+CREATE SECRET sf_missing_user (
+    TYPE snowflake,
+    ACCOUNT 'test_account',
+    PASSWORD 'test_password'
+)
+----
+Snowflake secret requires field 'user'
+
+# Test 6: Missing ACCOUNT should fail
+statement error
+CREATE SECRET sf_missing_account (
+    TYPE snowflake,
+    USER 'test_user',
+    PASSWORD 'test_password'
+)
+----
+Snowflake secret requires field 'account'
+
+# Cleanup
+statement ok
+DROP SECRET IF EXISTS sf_no_db_secret
+
+statement ok
+DROP SECRET IF EXISTS sf_with_db_secret


### PR DESCRIPTION
## Problem

Two related issues with the DATABASE parameter:

1. **Wrong ADBC option key** — The extension passes `adbc.snowflake.sql.database` to the ADBC driver, but the correct key is `adbc.snowflake.sql.db` ([ADBC Snowflake driver docs](https://arrow.apache.org/adbc/current/driver/snowflake.html)). This causes the DATABASE setting to be silently ignored — users have to use fully qualified table names or run `USE DATABASE` manually.

2. **DATABASE unnecessarily required** — Secret creation validation enforces DATABASE as a required field, but the client code already handles an empty database gracefully (it skips setting the ADBC option). Users who work across multiple databases or prefer fully qualified names should not be forced to specify one.

## Fix

- `snowflake_client.cpp`: Change `adbc.snowflake.sql.database` → `adbc.snowflake.sql.db`
- `snowflake_secret_provider.cpp`: Remove `database` from the `always_required` list in both `Validate()` and `CreateSnowflakeSecret()` (2 locations)

## Testing

- Added `test/sql/snowflake_database_parameter.test` — offline tests (no live Snowflake needed) that verify:
  - Secrets can be created **without** DATABASE ✓
  - Secrets can be created **with** DATABASE ✓  
  - USER and ACCOUNT remain required (error on omission) ✓
- Tested the ADBC key fix against a live Snowflake instance — `DATABASE` in the secret now correctly sets the default database without needing `USE DATABASE` or fully qualified names.