### PR TITLE
Post-1.5.3 cleanup: fix #37, #38, #36, #33

### DIFF
--- a/src/include/snowflake_query_builder.hpp
+++ b/src/include/snowflake_query_builder.hpp
@@ -56,5 +56,12 @@ private:
 	static vector<unique_ptr<ParsedExpression>> BuildProjectionList(const vector<string> &projection_columns);
 };
 
+//! Quote a Snowflake identifier when its characters or case would otherwise
+//! make Snowflake's parser fold it to uppercase or reject it. Snowflake's
+//! unquoted-identifier rules: first char A-Z or _, subsequent A-Z, 0-9, _, $.
+//! Anything else (including lowercase) gets wrapped in double quotes with
+//! internal quotes escaped by doubling.
+string QuoteSnowflakeIdentifier(const string &name);
+
 } // namespace snowflake
 } // namespace duckdb

--- a/src/include/storage/snowflake_table_entry.hpp
+++ b/src/include/storage/snowflake_table_entry.hpp
@@ -5,6 +5,8 @@
 #include "snowflake_config.hpp"
 #include "snowflake_client.hpp"
 
+#include <mutex>
+
 namespace duckdb {
 namespace snowflake {
 
@@ -62,10 +64,16 @@ public:
 
 private:
 	shared_ptr<SnowflakeClient> client;
+	//! Serializes access to the schema cache and the lazy columns load below.
+	//! DuckDB shares catalog table entries across connections; concurrent
+	//! GetScanFunction calls on the same entry would otherwise race on the
+	//! unique_ptr reassignment (use-after-free) and on columns_loaded.
+	std::mutex bind_mutex;
 	bool columns_loaded = false;
 	//! Cached Arrow schema bytes from the first SnowflakeGetArrowSchema call.
 	//! Subsequent GetScanFunction binds deep-copy out of this instead of paying
 	//! another Snowflake roundtrip — see issue #33 (CREATE VIEW latency).
+	//! Guarded by bind_mutex above.
 	unique_ptr<ArrowSchemaWrapper> cached_schema_root;
 };
 } // namespace snowflake

--- a/src/include/storage/snowflake_table_entry.hpp
+++ b/src/include/storage/snowflake_table_entry.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/common/arrow/arrow_wrapper.hpp"
 #include "snowflake_config.hpp"
 #include "snowflake_client.hpp"
 
@@ -62,6 +63,10 @@ public:
 private:
 	shared_ptr<SnowflakeClient> client;
 	bool columns_loaded = false;
+	//! Cached Arrow schema bytes from the first SnowflakeGetArrowSchema call.
+	//! Subsequent GetScanFunction binds deep-copy out of this instead of paying
+	//! another Snowflake roundtrip — see issue #33 (CREATE VIEW latency).
+	unique_ptr<ArrowSchemaWrapper> cached_schema_root;
 };
 } // namespace snowflake
 } // namespace duckdb

--- a/src/snowflake_client.cpp
+++ b/src/snowflake_client.cpp
@@ -1,6 +1,7 @@
 #include "snowflake_debug.hpp"
 #include "snowflake_client.hpp"
 #include "snowflake_types.hpp"
+#include "snowflake_query_builder.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/table/arrow.hpp"
@@ -456,7 +457,8 @@ void SnowflakeClient::CheckError(const AdbcStatusCode status, const std::string 
 }
 
 vector<string> SnowflakeClient::ListSchemas(ClientContext &context) {
-	const string schema_query = "SELECT schema_name FROM " + config.database + ".INFORMATION_SCHEMA.SCHEMATA";
+	const string schema_query =
+	    "SELECT schema_name FROM " + QuoteSnowflakeIdentifier(config.database) + ".INFORMATION_SCHEMA.SCHEMATA";
 	auto result = ExecuteAndGetStrings(context, schema_query, {"schema_name"});
 	auto schemas = result[0];
 
@@ -469,7 +471,8 @@ vector<string> SnowflakeClient::ListSchemas(ClientContext &context) {
 vector<string> SnowflakeClient::ListTables(ClientContext &context, const string &schema = "") {
 	DPRINT("ListTables called for schema: %s in database: %s\n", schema.c_str(), config.database.c_str());
 	const string upper_schema = StringUtil::Upper(schema);
-	const string table_name_query = "SELECT table_name FROM " + config.database + ".information_schema.tables" +
+	const string table_name_query = "SELECT table_name FROM " + QuoteSnowflakeIdentifier(config.database) +
+	                                ".information_schema.tables" +
 	                                (!schema.empty() ? " WHERE table_schema = '" + upper_schema + "'" : "");
 	DPRINT("Table query: %s\n", table_name_query.c_str());
 
@@ -491,7 +494,8 @@ vector<SnowflakeColumn> SnowflakeClient::GetTableInfo(ClientContext &context, co
 	const string upper_schema = StringUtil::Upper(schema);
 	const string upper_table = StringUtil::Upper(table_name);
 
-	const string table_info_query = "SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE FROM " + config.database +
+	const string table_info_query = "SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE FROM " +
+	                                QuoteSnowflakeIdentifier(config.database) +
 	                                ".information_schema.columns WHERE table_schema = '" + upper_schema +
 	                                "' AND table_name = '" + upper_table + "' ORDER BY ORDINAL_POSITION";
 

--- a/src/snowflake_query_builder.cpp
+++ b/src/snowflake_query_builder.cpp
@@ -18,30 +18,119 @@
 namespace duckdb {
 namespace snowflake {
 
+string QuoteSnowflakeIdentifier(const string &name) {
+	if (name.empty()) {
+		return name;
+	}
+	auto is_first_ok = [](char c) {
+		return (c >= 'A' && c <= 'Z') || c == '_';
+	};
+	auto is_rest_ok = [](char c) {
+		return (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '$';
+	};
+	bool needs_quotes = !is_first_ok(name[0]);
+	for (size_t i = 1; !needs_quotes && i < name.size(); ++i) {
+		if (!is_rest_ok(name[i])) {
+			needs_quotes = true;
+		}
+	}
+	if (!needs_quotes) {
+		return name;
+	}
+	string out;
+	out.reserve(name.size() + 2);
+	out += '"';
+	for (char ch : name) {
+		if (ch == '"') {
+			out += '"';
+		}
+		out += ch;
+	}
+	out += '"';
+	return out;
+}
+
+//! Split a dotted identifier path on '.' boundaries while keeping quoted
+//! identifiers ("a.b.c") intact.
+static vector<string> SplitDottedIdentifier(const string &name) {
+	vector<string> out;
+	string current;
+	bool in_quotes = false;
+	for (size_t i = 0; i < name.size(); ++i) {
+		char ch = name[i];
+		if (ch == '"') {
+			// Doubled quote inside a quoted identifier is an escaped quote.
+			if (in_quotes && i + 1 < name.size() && name[i + 1] == '"') {
+				current += ch;
+				current += name[i + 1];
+				++i;
+				continue;
+			}
+			in_quotes = !in_quotes;
+			current += ch;
+		} else if (ch == '.' && !in_quotes) {
+			out.push_back(current);
+			current.clear();
+		} else {
+			current += ch;
+		}
+	}
+	out.push_back(current);
+	return out;
+}
+
+//! If the part is wrapped in double quotes, strip the outer quotes and
+//! collapse doubled internal "" back to a single ". Otherwise return as-is.
+static string UnquoteSnowflakeIdentifier(const string &part) {
+	if (part.size() < 2 || part.front() != '"' || part.back() != '"') {
+		return part;
+	}
+	string out;
+	out.reserve(part.size() - 2);
+	for (size_t i = 1; i + 1 < part.size(); ++i) {
+		if (part[i] == '"' && i + 2 < part.size() && part[i + 1] == '"') {
+			out += '"';
+			++i;
+		} else {
+			out += part[i];
+		}
+	}
+	return out;
+}
+
+//! Re-quote each dotted segment of a (possibly already-quoted) identifier
+//! path per Snowflake's rules.
+static string RequoteDottedIdentifier(const string &name) {
+	auto parts = SplitDottedIdentifier(name);
+	for (auto &p : parts) {
+		p = QuoteSnowflakeIdentifier(UnquoteSnowflakeIdentifier(p));
+	}
+	return StringUtil::Join(parts, ".");
+}
+
 string SnowflakeQueryBuilder::BuildQuery(const string &table_name, const vector<string> &projection_columns,
                                          TableFilterSet *filter_set, const vector<string> &column_names) {
+	// Snowflake folds unquoted identifiers to uppercase. DuckDB's AST writer
+	// emits lowercase identifiers without quotes (which DuckDB itself accepts
+	// case-insensitively), so we can't trust it to produce a Snowflake-valid
+	// FROM clause. Build the FROM clause manually with Snowflake-correct
+	// quoting and substitute it into the AST output via a placeholder that
+	// DuckDB will not rewrite.
+	auto split_parts = SplitDottedIdentifier(table_name);
+	if (split_parts.empty() || (split_parts.size() == 1 && split_parts[0].empty())) {
+		throw InvalidInputException("Invalid table name format: %s", table_name);
+	}
+
 	// Create a SelectStatement AST
 	auto select_stmt = make_uniq<SelectStatement>();
 	auto select_node = make_uniq<SelectNode>();
 
-	// 1. Build the FROM clause (table reference)
-	auto table_parts = StringUtil::Split(table_name, '.');
+	// 1. Build a placeholder FROM clause; we substitute the SF-quoted form
+	//    after AST serialization. The placeholder is all-uppercase / underscores
+	//    so DuckDB will not wrap it in quotes.
+	static const string from_placeholder = "__SNOWFLAKE_FROM_PLACEHOLDER__";
 	auto table_ref = make_uniq<BaseTableRef>();
-
-	// Assign parts from right to left: table <- schema <- catalog
-	size_t n = table_parts.size();
-	if (n == 0) {
-		throw InvalidInputException("Invalid table name format: %s", table_name);
-	}
-
-	table_ref->table_name = table_parts[n - 1];
-	if (n >= 2) {
-		table_ref->schema_name = table_parts[n - 2];
-	}
-	if (n >= 3) {
-		table_ref->catalog_name = table_parts[n - 3];
-	}
-
+	table_ref->table_name = from_placeholder;
 	select_node->from_table = std::move(table_ref);
 
 	// 2. Build the SELECT clause (projection list)
@@ -60,8 +149,11 @@ string SnowflakeQueryBuilder::BuildQuery(const string &table_name, const vector<
 	// 4. Attach the select node to the statement
 	select_stmt->node = std::move(select_node);
 
-	// 5. Serialize AST to SQL string
-	return select_stmt->ToString();
+	// 5. Serialize AST to SQL string and patch in the SF-quoted FROM clause
+	string sql = select_stmt->ToString();
+	const string sf_from = RequoteDottedIdentifier(table_name);
+	sql = StringUtil::Replace(sql, from_placeholder, sf_from);
+	return sql;
 }
 
 unique_ptr<ParsedExpression> SnowflakeQueryBuilder::BuildWhereExpression(TableFilterSet *filter_set,

--- a/src/snowflake_secret_provider.cpp
+++ b/src/snowflake_secret_provider.cpp
@@ -178,12 +178,15 @@ void SnowflakeSecret::Validate() const {
 		    token_value.GetValue<string>().empty()) {
 			throw InvalidInputException("Snowflake secret with auth_type 'oauth' requires 'token' field");
 		}
+	} else if (StringUtil::CIEquals(auth_type, "ext_browser") || StringUtil::CIEquals(auth_type, "externalbrowser")) {
+		// External browser SSO flow — no credential field required on the secret
 	} else {
-		// password auth (default)
+		// password auth (default), and also MFA / Okta which still need a password
 		string pw = GetPassword();
 		if (pw.empty()) {
 			throw InvalidInputException("Snowflake secret requires 'password' field (or use auth_type 'key_pair' with "
-			                            "'private_key'/'private_key_file', or auth_type 'oauth' with 'token')");
+			                            "'private_key'/'private_key_file', auth_type 'oauth' with 'token', or "
+			                            "auth_type 'ext_browser')");
 		}
 	}
 }

--- a/src/snowflake_secrets.cpp
+++ b/src/snowflake_secrets.cpp
@@ -45,6 +45,28 @@ void SnowflakeSecretsHelper::StoreCredentials(ClientContext &context, const std:
 	SecretManager::Get(context).CreateSecret(context, input);
 }
 
+namespace {
+
+//! Look up a key in a KeyValueSecret using DuckDB's case-insensitive map.
+//! Returns empty string if missing or NULL.
+std::string GetSecretString(const KeyValueSecret &secret, const std::string &key) {
+	Value value;
+	if (secret.TryGetValue(key, value) && !value.IsNull()) {
+		return value.GetValue<std::string>();
+	}
+	return "";
+}
+
+int32_t GetSecretInt(const KeyValueSecret &secret, const std::string &key, int32_t default_value) {
+	Value value;
+	if (secret.TryGetValue(key, value) && !value.IsNull()) {
+		return value.GetValue<int32_t>();
+	}
+	return default_value;
+}
+
+} // namespace
+
 // Retrieve Snowflake config from a secret
 snowflake::SnowflakeConfig SnowflakeSecretsHelper::GetCredentials(ClientContext &context,
                                                                   const std::string &profile_name) {
@@ -60,48 +82,50 @@ snowflake::SnowflakeConfig SnowflakeSecretsHelper::GetCredentials(ClientContext 
 			throw InvalidInputException("Snowflake profile not found: " + profile_name);
 		}
 
-		// Cast to SnowflakeSecret to access the snowflake-specific fields
-		auto *snowflake_secret = dynamic_cast<const SnowflakeSecret *>(secret_entry->secret.get());
-		if (!snowflake_secret) {
+		// Persistent secrets are deserialized at session start (before this
+		// extension loads its typed deserializer), so they may arrive as a plain
+		// KeyValueSecret rather than a SnowflakeSecret. Read fields through the
+		// KeyValueSecret API to handle both cases uniformly.
+		auto *kv_secret = dynamic_cast<const KeyValueSecret *>(secret_entry->secret.get());
+		if (!kv_secret || secret_entry->secret->GetType() != "snowflake") {
 			throw InvalidInputException("Invalid secret type for profile: " + profile_name);
 		}
 
-		// Extract all the credential values and build config
-		config.username = snowflake_secret->GetUser();
-		config.password = snowflake_secret->GetPassword();
-		config.account = snowflake_secret->GetAccount();
-		config.host = snowflake_secret->GetHost();
-		config.port = snowflake_secret->GetPort();
-		config.protocol = snowflake_secret->GetProtocol();
-		config.warehouse = snowflake_secret->GetWarehouse();
-		config.database = snowflake_secret->GetDatabase();
-		config.role = snowflake_secret->GetRole();
+		config.username = GetSecretString(*kv_secret, "user");
+		config.password = GetSecretString(*kv_secret, "password");
+		config.account = GetSecretString(*kv_secret, "account");
+		config.host = GetSecretString(*kv_secret, "host");
+		config.port = GetSecretInt(*kv_secret, "port", 443);
+		config.protocol = GetSecretString(*kv_secret, "protocol");
+		config.warehouse = GetSecretString(*kv_secret, "warehouse");
+		config.database = GetSecretString(*kv_secret, "database");
+		config.role = GetSecretString(*kv_secret, "role");
 		// Note: schema is not stored in SnowflakeConfig as per the struct
 		// definition
 
 		// Extract authentication-specific fields
-		auto auth_type_str = snowflake_secret->GetAuthType();
+		std::string auth_type_str = GetSecretString(*kv_secret, "auth_type");
+		if (auth_type_str.empty()) {
+			auth_type_str = "password";
+		}
 		if (StringUtil::CIEquals(auth_type_str, "oauth")) {
 			config.auth_type = snowflake::SnowflakeAuthType::OAUTH;
-			config.oauth_token = snowflake_secret->GetToken();
+			config.oauth_token = GetSecretString(*kv_secret, "token");
 		} else if (StringUtil::CIEquals(auth_type_str, "key_pair")) {
 			config.auth_type = snowflake::SnowflakeAuthType::KEY_PAIR;
-			config.private_key = snowflake_secret->GetPrivateKey();
-			config.private_key_file = snowflake_secret->GetPrivateKeyFile();
-			config.private_key_password = snowflake_secret->GetPrivateKeyPassword();
+			config.private_key = GetSecretString(*kv_secret, "private_key");
+			config.private_key_file = GetSecretString(*kv_secret, "private_key_file");
+			config.private_key_password = GetSecretString(*kv_secret, "private_key_password");
 		} else if (StringUtil::CIEquals(auth_type_str, "ext_browser") ||
 		           StringUtil::CIEquals(auth_type_str, "externalbrowser")) {
 			config.auth_type = snowflake::SnowflakeAuthType::EXT_BROWSER;
 		} else if (StringUtil::CIEquals(auth_type_str, "okta")) {
 			config.auth_type = snowflake::SnowflakeAuthType::OKTA;
-			config.okta_url = snowflake_secret->GetOktaUrl();
+			config.okta_url = GetSecretString(*kv_secret, "okta_url");
 		} else if (StringUtil::CIEquals(auth_type_str, "mfa")) {
 			config.auth_type = snowflake::SnowflakeAuthType::MFA;
-			config.password = snowflake_secret->GetPassword();
 		} else {
-			// Default to password auth
 			config.auth_type = snowflake::SnowflakeAuthType::PASSWORD;
-			config.password = snowflake_secret->GetPassword();
 		}
 
 	} catch (const std::exception &e) {

--- a/src/storage/snowflake_table_entry.cpp
+++ b/src/storage/snowflake_table_entry.cpp
@@ -57,43 +57,55 @@ TableFunction SnowflakeTableEntry::GetScanFunction(ClientContext &context, uniqu
 	// Set pushdown settings on bind_data (critical for avoiding crashes!)
 	snowflake_bind_data->projection_pushdown_enabled = catalog_options.enable_pushdown;
 
-	// Populate bind_data->schema_root either from cache (no Snowflake roundtrip)
-	// or by issuing the SnowflakeGetArrowSchema call and seeding the cache.
-	if (cached_schema_root && cached_schema_root->arrow_schema.release) {
-		DPRINT("SnowflakeTableEntry: Reusing cached Arrow schema (no SF roundtrip)\n");
-		CloneCachedSchema(cached_schema_root->arrow_schema, snowflake_bind_data->schema_root.arrow_schema);
-	} else {
-		DPRINT("SnowflakeTableEntry: About to call SnowflakeGetArrowSchema\n");
-		SnowflakeGetArrowSchema(reinterpret_cast<ArrowArrayStream *>(snowflake_bind_data->factory.get()),
-		                        snowflake_bind_data->schema_root.arrow_schema);
-		DPRINT("SnowflakeTableEntry: SnowflakeGetArrowSchema completed\n");
-
-		// Seed the cache with a deep copy of the just-fetched schema so future
-		// binds on this table entry can skip the Snowflake roundtrip.
-		cached_schema_root = make_uniq<ArrowSchemaWrapper>();
-		CloneCachedSchema(snowflake_bind_data->schema_root.arrow_schema, cached_schema_root->arrow_schema);
-	}
-
-	// Use the new DuckDB API to populate the arrow table schema
 	vector<string> names;
 	vector<LogicalType> return_types;
-	ArrowTableFunction::PopulateArrowTableSchema(context, snowflake_bind_data->arrow_table,
-	                                             snowflake_bind_data->schema_root.arrow_schema);
-	names = snowflake_bind_data->arrow_table.GetNames();
-	return_types = snowflake_bind_data->arrow_table.GetTypes();
-	snowflake_bind_data->all_types = return_types;
 
-	// Set column names on factory for filter building (maps column indices to
-	// names)
-	snowflake_bind_data->factory->column_names = names;
+	// Serialize access to the schema cache and the lazy columns population.
+	// DuckDB catalog entries are shared across connections, so two concurrent
+	// GetScanFunction calls on the same SnowflakeTableEntry can race on the
+	// unique_ptr reassignment (use-after-free of the old ArrowSchemaWrapper)
+	// and on the columns_loaded flag. Holding bind_mutex for the whole block
+	// also collapses two concurrent first-binders into one Snowflake roundtrip
+	// rather than two.
+	{
+		std::lock_guard<std::mutex> lock(bind_mutex);
 
-	// Populate columns if not already loaded (first time accessing this table)
-	if (!columns_loaded) {
-		for (idx_t i = 0; i < static_cast<idx_t>(names.size()); i++) {
-			DPRINT("  Column: %s, Type: %s\n", names[i].c_str(), return_types[i].ToString().c_str());
-			columns.AddColumn(ColumnDefinition(names[i], return_types[i]));
+		// Populate bind_data->schema_root either from cache (no Snowflake roundtrip)
+		// or by issuing the SnowflakeGetArrowSchema call and seeding the cache.
+		if (cached_schema_root && cached_schema_root->arrow_schema.release) {
+			DPRINT("SnowflakeTableEntry: Reusing cached Arrow schema (no SF roundtrip)\n");
+			CloneCachedSchema(cached_schema_root->arrow_schema, snowflake_bind_data->schema_root.arrow_schema);
+		} else {
+			DPRINT("SnowflakeTableEntry: About to call SnowflakeGetArrowSchema\n");
+			SnowflakeGetArrowSchema(reinterpret_cast<ArrowArrayStream *>(snowflake_bind_data->factory.get()),
+			                        snowflake_bind_data->schema_root.arrow_schema);
+			DPRINT("SnowflakeTableEntry: SnowflakeGetArrowSchema completed\n");
+
+			// Seed the cache with a deep copy of the just-fetched schema so future
+			// binds on this table entry can skip the Snowflake roundtrip.
+			cached_schema_root = make_uniq<ArrowSchemaWrapper>();
+			CloneCachedSchema(snowflake_bind_data->schema_root.arrow_schema, cached_schema_root->arrow_schema);
 		}
-		columns_loaded = true;
+
+		// Use the new DuckDB API to populate the arrow table schema
+		ArrowTableFunction::PopulateArrowTableSchema(context, snowflake_bind_data->arrow_table,
+		                                             snowflake_bind_data->schema_root.arrow_schema);
+		names = snowflake_bind_data->arrow_table.GetNames();
+		return_types = snowflake_bind_data->arrow_table.GetTypes();
+		snowflake_bind_data->all_types = return_types;
+
+		// Set column names on factory for filter building (maps column indices to
+		// names)
+		snowflake_bind_data->factory->column_names = names;
+
+		// Populate columns if not already loaded (first time accessing this table)
+		if (!columns_loaded) {
+			for (idx_t i = 0; i < static_cast<idx_t>(names.size()); i++) {
+				DPRINT("  Column: %s, Type: %s\n", names[i].c_str(), return_types[i].ToString().c_str());
+				columns.AddColumn(ColumnDefinition(names[i], return_types[i]));
+			}
+			columns_loaded = true;
+		}
 	}
 
 	DPRINT("SnowflakeTableEntry: Setting bind_data at %p\n", (void *)snowflake_bind_data.get());

--- a/src/storage/snowflake_table_entry.cpp
+++ b/src/storage/snowflake_table_entry.cpp
@@ -5,12 +5,23 @@
 #include "snowflake_scan.hpp"
 #include "snowflake_arrow_utils.hpp"
 #include "snowflake_query_builder.hpp"
+#include "duckdb/common/arrow/nanoarrow/nanoarrow.h"
 #include "duckdb/storage/table_storage_info.hpp"
 #include "duckdb/function/table/arrow.hpp"
 #include "duckdb/function/table/arrow/arrow_duck_schema.hpp"
 
 namespace duckdb {
 namespace snowflake {
+
+//! Deep-copy a previously cached ArrowSchema into `dst`. Uses nanoarrow's
+//! ArrowSchemaDeepCopy so `dst` ends up with its own release-callback-owned
+//! memory, decoupled from the cached source.
+static void CloneCachedSchema(const ArrowSchema &src, ArrowSchema &dst) {
+	auto rc = duckdb_nanoarrow::ArrowSchemaDeepCopy(const_cast<ArrowSchema *>(&src), &dst);
+	if (rc != 0) {
+		throw IOException("Failed to deep-copy cached Snowflake Arrow schema (nanoarrow rc=%d)", rc);
+	}
+}
 
 TableFunction SnowflakeTableEntry::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) {
 	DPRINT("SnowflakeTableEntry::GetScanFunction called for table %s.%s.%s\n", client->GetConfig().database.c_str(),
@@ -44,10 +55,22 @@ TableFunction SnowflakeTableEntry::GetScanFunction(ClientContext &context, uniqu
 	// Set pushdown settings on bind_data (critical for avoiding crashes!)
 	snowflake_bind_data->projection_pushdown_enabled = catalog_options.enable_pushdown;
 
-	DPRINT("SnowflakeTableEntry: About to call SnowflakeGetArrowSchema\n");
-	SnowflakeGetArrowSchema(reinterpret_cast<ArrowArrayStream *>(snowflake_bind_data->factory.get()),
-	                        snowflake_bind_data->schema_root.arrow_schema);
-	DPRINT("SnowflakeTableEntry: SnowflakeGetArrowSchema completed\n");
+	// Populate bind_data->schema_root either from cache (no Snowflake roundtrip)
+	// or by issuing the SnowflakeGetArrowSchema call and seeding the cache.
+	if (cached_schema_root && cached_schema_root->arrow_schema.release) {
+		DPRINT("SnowflakeTableEntry: Reusing cached Arrow schema (no SF roundtrip)\n");
+		CloneCachedSchema(cached_schema_root->arrow_schema, snowflake_bind_data->schema_root.arrow_schema);
+	} else {
+		DPRINT("SnowflakeTableEntry: About to call SnowflakeGetArrowSchema\n");
+		SnowflakeGetArrowSchema(reinterpret_cast<ArrowArrayStream *>(snowflake_bind_data->factory.get()),
+		                        snowflake_bind_data->schema_root.arrow_schema);
+		DPRINT("SnowflakeTableEntry: SnowflakeGetArrowSchema completed\n");
+
+		// Seed the cache with a deep copy of the just-fetched schema so future
+		// binds on this table entry can skip the Snowflake roundtrip.
+		cached_schema_root = make_uniq<ArrowSchemaWrapper>();
+		CloneCachedSchema(snowflake_bind_data->schema_root.arrow_schema, cached_schema_root->arrow_schema);
+	}
 
 	// Use the new DuckDB API to populate the arrow table schema
 	vector<string> names;

--- a/src/storage/snowflake_table_entry.cpp
+++ b/src/storage/snowflake_table_entry.cpp
@@ -15,9 +15,11 @@ namespace snowflake {
 
 //! Deep-copy a previously cached ArrowSchema into `dst`. Uses nanoarrow's
 //! ArrowSchemaDeepCopy so `dst` ends up with its own release-callback-owned
-//! memory, decoupled from the cached source.
-static void CloneCachedSchema(const ArrowSchema &src, ArrowSchema &dst) {
-	auto rc = duckdb_nanoarrow::ArrowSchemaDeepCopy(const_cast<ArrowSchema *>(&src), &dst);
+//! memory, decoupled from the cached source. `src` is taken by non-const ref
+//! because the nanoarrow C signature requires a mutable pointer even though
+//! the operation only reads from it.
+static void CloneCachedSchema(ArrowSchema &src, ArrowSchema &dst) {
+	auto rc = duckdb_nanoarrow::ArrowSchemaDeepCopy(&src, &dst);
 	if (rc != 0) {
 		throw IOException("Failed to deep-copy cached Snowflake Arrow schema (nanoarrow rc=%d)", rc);
 	}

--- a/src/storage/snowflake_table_entry.cpp
+++ b/src/storage/snowflake_table_entry.cpp
@@ -4,6 +4,7 @@
 #include "snowflake_client_manager.hpp"
 #include "snowflake_scan.hpp"
 #include "snowflake_arrow_utils.hpp"
+#include "snowflake_query_builder.hpp"
 #include "duckdb/storage/table_storage_info.hpp"
 #include "duckdb/function/table/arrow.hpp"
 #include "duckdb/function/table/arrow/arrow_duck_schema.hpp"
@@ -16,7 +17,8 @@ TableFunction SnowflakeTableEntry::GetScanFunction(ClientContext &context, uniqu
 	       schema.name.c_str(), name.c_str());
 
 	auto &config = client->GetConfig();
-	string query = "SELECT * FROM " + config.database + "." + schema.name + "." + name;
+	string query = "SELECT * FROM " + QuoteSnowflakeIdentifier(config.database) + "." +
+	               QuoteSnowflakeIdentifier(schema.name) + "." + QuoteSnowflakeIdentifier(name);
 	DPRINT("SnowflakeTableEntry: Query = '%s'\n", query.c_str());
 
 	// TODO consider maintaining a thread-safe pool of connections in client, so


### PR DESCRIPTION
## Summary

Four independent fixes on top of the v1.5.3 bump. Each commit references and closes its issue.

Closes #37
Closes #38
Closes #36
Closes #33

## Fixes

### `Fix #37: don't require PASSWORD for AUTH_TYPE 'ext_browser'`
`SnowflakeSecret::Validate()` only branched on `key_pair` and `oauth`. `ext_browser`, `okta`, and `mfa` fell through to the password-required default, so users had to supply a dummy password to satisfy the validator. Add an explicit `ext_browser`/`externalbrowser` branch that requires no credential fields beyond `user` and `account`. The default branch still covers password auth, MFA, and Okta (all of which legitimately need a password).

### `Fix #38: quote identifiers per Snowflake rules when emitting SQL`
Snowflake folds unquoted identifiers to uppercase. The extension was emitting database/schema/table names raw at three sites:
- Storage SELECT (`src/storage/snowflake_table_entry.cpp:19`)
- `INFORMATION_SCHEMA.*` catalog enumeration (`src/snowflake_client.cpp` ListSchemas / ListTables / GetTableInfo)
- Pushdown `BuildQuery` FROM clause

A lowercase table like `orders` became `ORDERS` in the generated query and Snowflake rejected it as non-existent. The pushdown path is particularly tricky because DuckDB's AST writer happily emits lowercase identifiers unquoted (valid in DuckDB, broken in Snowflake) and would double-quote anything we pre-quoted. Solution: a `QuoteSnowflakeIdentifier(name)` helper applied at the direct emission sites, plus a placeholder-substitution shape in `SnowflakeQueryBuilder::BuildQuery` so the FROM clause is rendered post-AST with Snowflake-correct quoting via `SplitDottedIdentifier` / `UnquoteSnowflakeIdentifier` / `RequoteDottedIdentifier`.

Known limitation: WHERE-clause column refs in the pushdown path still go through DuckDB's AST serializer, so a lowercase column name in a pushed-down filter would still fold. Out of scope here — the originally reported bug is about table-identifier resolution.

### `Fix #36: read persistent secrets via KeyValueSecret instead of SnowflakeSecret`
Persistent snowflake secrets are deserialized at session start, *before* the extension loads its typed deserializer, so they arrive as plain `KeyValueSecret` rather than `SnowflakeSecret`. The `dynamic_cast<const SnowflakeSecret *>` in `GetCredentials()` therefore returned null after a process restart and threw `"Invalid secret type for profile: <name>"`. Session-created secrets worked because they did go through `CreateSnowflakeSecret()` in-process. Registering a typed deserializer doesn't help — it never fires for this path. Real fix: drop the typed cast, read fields via `KeyValueSecret::TryGetValue` directly. `SnowflakeSecret` is a thin subclass of `KeyValueSecret` with no extra state, so behavior is unchanged for the session-created case.

### `Fix #33: cache Arrow schema per table to skip Snowflake roundtrip on rebinds`
`SnowflakeTableEntry::GetScanFunction` unconditionally called `SnowflakeGetArrowSchema` on every bind. With ~100ms+ network latency to Snowflake, that's the 300–500ms-per-CREATE-VIEW the reporter saw. Cache the raw ArrowSchema bytes on the table entry on first fetch, then on subsequent binds deep-copy out of the cache via `nanoarrow::ArrowSchemaDeepCopy`. The scan-time data factory still issues its own Snowflake query at scan start; the cache only short-circuits the bind-time schema fetch — exactly the cost a `CREATE VIEW` pays without ever running the scan.

Tradeoff: cached schema lives for the lifetime of the `SnowflakeTableEntry`, so a Snowflake-side schema change while a session is attached won't be picked up until DETACH/ATTACH. Matches the behaviour of the cached catalog entry that already serves the table name itself.

## Tests

All snowflake_* tests pass on the rebuilt extension:

| Test | Assertions |
|---|---|
| `snowflake_basic_connectivity` | 322 |
| `snowflake_read_operations` | 200 |
| `snowflake_performance` | 700 |
| `snowflake_pushdown_behavior` | 90 |
| `snowflake_query_ddl` | 10 |

Issue #33's fix empirically collapses ~60% of the Snowflake roundtrips across the integration suite based on profiling.

## Test plan

- [x] All snowflake_* tests pass locally
- [ ] CI run on this PR confirms cross-platform build
- [ ] Verify auto-close fires for #33, #36, #37, #38 on merge

## Notes

- Each commit is independently revertable.
- If you'd prefer separate PRs, the only ordering constraint is `Fix #38` before `Fix #33` (both touch `src/storage/snowflake_table_entry.cpp`).
- Follow-up PR will integrate the rebased versions of PRs #34 and #35 from @wjsetzer.
