### PR TITLE
Add explicit contents:read permissions to three workflow jobs

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -19,6 +19,8 @@ env:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
+    permissions:
+      contents: read
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.3
     with:
       duckdb_version: v1.5.3
@@ -29,6 +31,8 @@ jobs:
 
   code-quality-check:
     name: Code Quality Check
+    permissions:
+      contents: read
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@v1.5.3
     with:
       duckdb_version: v1.5.3

--- a/.github/workflows/test-with-snowflake.yml
+++ b/.github/workflows/test-with-snowflake.yml
@@ -9,6 +9,8 @@ jobs:
   test-snowflake:
     name: Test Snowflake Extension
     runs-on: macos-latest
+    permissions:
+      contents: read
     if: ${{ vars.SKIP_SNOWFLAKE_TESTS != 'true' }}
     
     steps:


### PR DESCRIPTION
## Summary

Adds explicit `permissions: contents: read` to the three workflow jobs that CodeQL's `actions/missing-workflow-permissions` rule has been flagging since 2025-12-18 and 2026-03-13. No behavior change — just clears three stale warnings on `main`.

## What the alerts say

CodeQL flagged three jobs as relying on the default `GITHUB_TOKEN` permissions, which are broader than needed. The recommendation is to set an explicit `permissions:` block so each job has only the access it requires.

| Alert | File | Job | Created |
|---|---|---|---|
| #1 | `.github/workflows/MainDistributionPipeline.yml:21` | `duckdb-stable-build` | 2025-12-18 |
| #5 | `.github/workflows/MainDistributionPipeline.yml:31` | `code-quality-check` | 2026-03-13 |
| #2 | `.github/workflows/test-with-snowflake.yml:10` | `test-snowflake` | 2025-12-18 |

The fourth job in `MainDistributionPipeline.yml` (`build-complete-packages`) already has `permissions: contents: read` on it, which is why CodeQL doesn't flag it. This PR brings the other three into the same shape.

## Why `contents: read`

Each of the three flagged jobs does one of: checkout, build, or run the reusable distribution / code-quality workflows. None of them write to the repo, post to issues/PRs, publish packages, or modify any GitHub-managed state. `contents: read` is the documented minimum for checkout-and-build flows and matches what `build-complete-packages` already declares.

The reusable workflows (`_extension_distribution.yml`, `_extension_code_quality.yml`) inherit the caller's permissions; `contents: read` is sufficient for both based on what `build-complete-packages` already proves out.

## No behavior change

The default `GITHUB_TOKEN` permissions on this repo already grant `contents: read` (and more). Restricting to exactly `contents: read` removes the unused excess but doesn't take anything away that the workflows were relying on.

## Test plan

- [x] YAML still parses (visual diff inspection)
- [ ] CI run on this PR confirms all three jobs still pass
- [ ] After merge, confirm the three CodeQL alerts (#1, #2, #5) auto-resolve

## Notes

- Pre-existing on `main` for months — this is hygiene, not security-incident response.
- Doesn't touch the dependabot or secret-scanning streams (both currently empty on this repo).
