### PR TITLE
Attached-catalog and snowflake_query fixes: #38 follow-up, #44 TIMESTAMP_NTZ, #32 projection SIGSEGV

### DIFF
--- a/src/include/snowflake_arrow_utils.hpp
+++ b/src/include/snowflake_arrow_utils.hpp
@@ -38,6 +38,11 @@ struct SnowflakeArrowStreamFactory {
 	bool filter_pushdown_enabled = false;
 	bool projection_pushdown_enabled = false;
 
+	// True for the snowflake_query() passthrough SELECT path: the base query is
+	// arbitrary user SQL, so projection is applied by wrapping it as a subquery
+	// (SELECT <cols> FROM (<query>)) rather than by parsing a table name out of it.
+	bool wrap_as_subquery = false;
+
 	// Pushdown parameters (set by DuckDB via UpdatePushdownParameters)
 	vector<string> projection_columns;
 	TableFilterSet *current_filters = nullptr;
@@ -65,6 +70,14 @@ struct SnowflakeArrowStreamFactory {
 	// This is called by DuckDB when it wants to push filters and projections to
 	// the source
 	void UpdatePushdownParameters(const vector<string> &projection, TableFilterSet *filter_set);
+
+	// Apply a projection to the snowflake_query() passthrough path by wrapping the
+	// user query as a subquery: SELECT <quoted projection cols> FROM (<query>).
+	// DuckDB's Arrow scanner reads projected columns positionally (child[k] == the
+	// k-th requested column), so the produced stream MUST expose exactly these
+	// columns in this order — see issue #32 (wrong-column reads / SIGSEGV when the
+	// produced stream returned all columns regardless of the projection).
+	void UpdatePassthroughProjection(const vector<string> &projection);
 };
 
 // Function to produce an ArrowArrayStreamWrapper from the factory

--- a/src/include/snowflake_arrow_utils.hpp
+++ b/src/include/snowflake_arrow_utils.hpp
@@ -84,6 +84,16 @@ unique_ptr<ArrowArrayStreamWrapper> SnowflakeProduceArrowScan(uintptr_t factory_
 //   Arrow schema
 void SnowflakeGetArrowSchema(ArrowArrayStream *factory_ptr, ArrowSchema &schema);
 
+// Fetch the Arrow schema by executing the query with a 0-row limit, instead of
+// AdbcStatementExecuteSchema. The ADBC driver's ExecuteSchema metadata reports a
+// timestamp unit/precision (and tz) for Snowflake TIMESTAMP types that disagrees
+// with the unit it actually emits on the data stream (issue #44: TIMESTAMP_NTZ(6)
+// read as nanoseconds via the attached catalog). Running the real query with
+// `LIMIT 0` returns the authoritative data-path schema with zero data scanned.
+// Uses a temporary statement and stream that are released before returning, so it
+// does not disturb the factory's own statement used later during scan production.
+void SnowflakeGetArrowSchemaViaQuery(SnowflakeArrowStreamFactory *factory, ArrowSchema &schema);
+
 // Execute the query and cache the resulting Arrow stream in the factory.
 // Also populates schema from the stream's get_schema callback.
 // Used by snowflake_query bind to avoid double-execution: the cached stream is

--- a/src/include/snowflake_query_builder.hpp
+++ b/src/include/snowflake_query_builder.hpp
@@ -63,5 +63,13 @@ private:
 //! internal quotes escaped by doubling.
 string QuoteSnowflakeIdentifier(const string &name);
 
+//! Test-only: render the SQL that SnowflakeQueryBuilder::BuildQuery would emit
+//! for a given table, projection list (comma-separated), and optional single
+//! equality filter on one of the projected columns. Lets query_builder.test
+//! assert Snowflake-correct identifier quoting without a live Snowflake table
+//! that has lowercase column names.
+string RenderPushdownQueryForTest(const string &table_name, const string &projection_csv,
+                                  const string &filter_eq_column);
+
 } // namespace snowflake
 } // namespace duckdb

--- a/src/snowflake_arrow_utils.cpp
+++ b/src/snowflake_arrow_utils.cpp
@@ -73,8 +73,14 @@ unique_ptr<ArrowArrayStreamWrapper> SnowflakeProduceArrowScan(uintptr_t factory_
 			projection_cols.push_back(col);
 		}
 
-		// Call UpdatePushdownParameters to build modified query
-		factory->UpdatePushdownParameters(projection_cols, parameters.filters);
+		// Build the modified query. The snowflake_query() passthrough path wraps the
+		// user SQL as a subquery (projection only); the ATTACH path parses the table
+		// name out of the base query and rebuilds it.
+		if (factory->wrap_as_subquery) {
+			factory->UpdatePassthroughProjection(projection_cols);
+		} else {
+			factory->UpdatePushdownParameters(projection_cols, parameters.filters);
+		}
 	} else {
 		// No pushdown - use original query as-is (like main branch behavior)
 		DPRINT("Pushdown disabled, using original query: %s\n", factory->query.c_str());
@@ -404,6 +410,30 @@ void SnowflakeArrowStreamFactory::UpdatePushdownParameters(const vector<string> 
 		DPRINT("Pushdown failed: %s, using original query\n", e.what());
 		modified_query = query;
 	}
+}
+
+void SnowflakeArrowStreamFactory::UpdatePassthroughProjection(const vector<string> &projection) {
+	projection_columns = projection;
+
+	// No projection requested (e.g. SELECT *): run the user query unchanged.
+	if (projection.empty()) {
+		modified_query = query;
+		return;
+	}
+
+	// Select exactly the requested columns, in the requested order, from the user
+	// query wrapped as a derived table. The names come from the result schema, so
+	// quoting the exact name round-trips for both folded-uppercase and
+	// case-sensitive columns.
+	string cols;
+	for (size_t i = 0; i < projection.size(); i++) {
+		if (i > 0) {
+			cols += ", ";
+		}
+		cols += snowflake::QuoteSnowflakeIdentifier(projection[i]);
+	}
+	modified_query = "SELECT " + cols + " FROM (" + query + ") AS __sf_passthrough";
+	DPRINT("Passthrough projection applied:\n  Original: %s\n  Modified: %s\n", query.c_str(), modified_query.c_str());
 }
 
 } // namespace duckdb

--- a/src/snowflake_arrow_utils.cpp
+++ b/src/snowflake_arrow_utils.cpp
@@ -223,6 +223,76 @@ void SnowflakeGetArrowSchema(ArrowArrayStream *factory_ptr, ArrowSchema &schema)
 	}
 }
 
+void SnowflakeGetArrowSchemaViaQuery(SnowflakeArrowStreamFactory *factory, ArrowSchema &schema) {
+	// Wrap the bind query as a 0-row subquery so Snowflake returns the column
+	// schema without scanning data. We take the schema from the executed stream
+	// (the data path) rather than AdbcStatementExecuteSchema, whose metadata
+	// mis-reports Snowflake TIMESTAMP units (see header / issue #44).
+	std::string probe_query = "SELECT * FROM (" + factory->modified_query + ") AS __sf_schema_probe LIMIT 0";
+
+	AdbcError error;
+	std::memset(&error, 0, sizeof(error));
+
+	// Use a temporary statement so we don't initialize/consume factory->statement,
+	// which the scan production path creates and uses on its own.
+	AdbcStatement probe_stmt;
+	std::memset(&probe_stmt, 0, sizeof(probe_stmt));
+	AdbcStatusCode status = AdbcStatementNew(factory->connection->GetConnection(), &probe_stmt, &error);
+	if (status != ADBC_STATUS_OK) {
+		throw IOException("Failed to create statement for schema probe");
+	}
+
+	status = AdbcStatementSetSqlQuery(&probe_stmt, probe_query.c_str(), &error);
+	if (status != ADBC_STATUS_OK) {
+		std::string msg = "Failed to set schema-probe query: ";
+		if (error.message) {
+			msg += error.message;
+			if (error.release) {
+				error.release(&error);
+			}
+		}
+		AdbcStatementRelease(&probe_stmt, nullptr);
+		throw IOException(msg);
+	}
+
+	ArrowArrayStream probe_stream;
+	std::memset(&probe_stream, 0, sizeof(probe_stream));
+	int64_t rows_affected = 0;
+	AdbcError exec_error;
+	std::memset(&exec_error, 0, sizeof(exec_error));
+	status = AdbcStatementExecuteQuery(&probe_stmt, &probe_stream, &rows_affected, &exec_error);
+	if (status != ADBC_STATUS_OK) {
+		std::string msg = "Failed to execute schema-probe query: ";
+		if (exec_error.message) {
+			msg += exec_error.message;
+			if (exec_error.release) {
+				exec_error.release(&exec_error);
+			}
+		}
+		AdbcStatementRelease(&probe_stmt, nullptr);
+		if (IsAuthenticationError(msg)) {
+			auto &client_manager = snowflake::SnowflakeClientManager::GetInstance();
+			client_manager.InvalidateConnection(factory->connection->GetConfig());
+			throw IOException(msg + "\n\nThe authentication token may have expired. "
+			                        "Please retry your query - a fresh connection will be established automatically.");
+		}
+		throw IOException(msg);
+	}
+
+	std::memset(&schema, 0, sizeof(schema));
+	int rc = probe_stream.get_schema ? probe_stream.get_schema(&probe_stream, &schema) : -1;
+
+	// Release the probe stream and statement; the caller only needs the schema.
+	if (probe_stream.release) {
+		probe_stream.release(&probe_stream);
+	}
+	AdbcStatementRelease(&probe_stmt, nullptr);
+
+	if (rc != 0) {
+		throw IOException("Failed to get schema from schema-probe stream");
+	}
+}
+
 void SnowflakeExecuteAndCacheStream(SnowflakeArrowStreamFactory *factory, ArrowSchema &schema) {
 	AdbcError error;
 	std::memset(&error, 0, sizeof(error));

--- a/src/snowflake_extension.cpp
+++ b/src/snowflake_extension.cpp
@@ -15,7 +15,9 @@
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_transaction.hpp"
 #include "duckdb/storage/storage_extension.hpp"
+#include "duckdb/common/vector_operations/ternary_executor.hpp"
 #include "snowflake_secret_provider.hpp"
+#include "snowflake_query_builder.hpp"
 
 namespace duckdb {
 
@@ -29,6 +31,19 @@ inline void SnowflakeVersionScalarFun(DataChunk &args, ExpressionState &state, V
 	result.SetValue(0, val);
 }
 
+//! Test-only: exposes SnowflakeQueryBuilder::BuildQuery as a scalar so
+//! query_builder.test can assert Snowflake-correct identifier quoting on the
+//! rendered SQL without needing a Snowflake table with lowercase columns.
+inline void SnowflakeRenderPushdownQueryFun(DataChunk &args, ExpressionState &state, Vector &result) {
+	TernaryExecutor::Execute<string_t, string_t, string_t, string_t>(
+	    args.data[0], args.data[1], args.data[2], result, args.size(),
+	    [&](string_t table, string_t projection_csv, string_t filter_eq_column) {
+		    auto rendered = snowflake::RenderPushdownQueryForTest(table.GetString(), projection_csv.GetString(),
+		                                                          filter_eq_column.GetString());
+		    return StringVector::AddString(result, rendered);
+	    });
+}
+
 // Compatibility layer for different DuckDB versions
 static void LoadInternal(ExtensionLoader &loader) {
 	// Register the custom Snowflake secret type
@@ -38,6 +53,13 @@ static void LoadInternal(ExtensionLoader &loader) {
 	auto snowflake_version_function =
 	    ScalarFunction("snowflake_version", {}, LogicalType::VARCHAR, SnowflakeVersionScalarFun);
 	loader.RegisterFunction(std::move(snowflake_version_function));
+
+	// Test-only: render the SQL that pushdown would emit for a given table +
+	// projection + (optional) single equality filter. Used by query_builder.test.
+	auto snowflake_render_pushdown_query_function = ScalarFunction(
+	    "snowflake_render_pushdown_query", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	    LogicalType::VARCHAR, SnowflakeRenderPushdownQueryFun);
+	loader.RegisterFunction(std::move(snowflake_render_pushdown_query_function));
 
 #ifdef ADBC_AVAILABLE
 	// Register snowflake_scan table function (only available when ADBC is

--- a/src/snowflake_query_builder.cpp
+++ b/src/snowflake_query_builder.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/parser/expression/conjunction_expression.hpp"
 #include "duckdb/parser/expression/operator_expression.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
+#include "duckdb/planner/filter/constant_filter.hpp"
 #include "duckdb/planner/filter/optional_filter.hpp"
 #include "duckdb/planner/filter/in_filter.hpp"
 #include "duckdb/planner/filter/dynamic_filter.hpp"
@@ -115,10 +116,39 @@ string SnowflakeQueryBuilder::BuildQuery(const string &table_name, const vector<
 	// case-insensitively), so we can't trust it to produce a Snowflake-valid
 	// FROM clause. Build the FROM clause manually with Snowflake-correct
 	// quoting and substitute it into the AST output via a placeholder that
-	// DuckDB will not rewrite.
+	// DuckDB will not rewrite. Column identifiers (projection list + filter
+	// column refs) have the same problem; we route them through per-column
+	// placeholders that get substituted with QuoteSnowflakeIdentifier output
+	// after ToString().
 	auto split_parts = SplitDottedIdentifier(table_name);
 	if (split_parts.empty() || (split_parts.size() == 1 && split_parts[0].empty())) {
 		throw InvalidInputException("Invalid table name format: %s", table_name);
+	}
+
+	// Build a placeholder for every column name we will reference. Placeholders
+	// are uppercase/underscores so DuckDB's serializer leaves them alone, and
+	// distinct enough that StringUtil::Replace won't collide.
+	std::map<string, string> col_to_placeholder;
+	auto placeholder_for = [&](const string &name) -> string {
+		auto it = col_to_placeholder.find(name);
+		if (it != col_to_placeholder.end()) {
+			return it->second;
+		}
+		string ph = StringUtil::Format("__SF_COL_%llu__", (uint64_t)col_to_placeholder.size());
+		col_to_placeholder[name] = ph;
+		return ph;
+	};
+
+	vector<string> projection_placeholders;
+	projection_placeholders.reserve(projection_columns.size());
+	for (const auto &c : projection_columns) {
+		projection_placeholders.push_back(placeholder_for(c));
+	}
+
+	vector<string> column_name_placeholders;
+	column_name_placeholders.reserve(column_names.size());
+	for (const auto &c : column_names) {
+		column_name_placeholders.push_back(placeholder_for(c));
 	}
 
 	// Create a SelectStatement AST
@@ -133,15 +163,15 @@ string SnowflakeQueryBuilder::BuildQuery(const string &table_name, const vector<
 	table_ref->table_name = from_placeholder;
 	select_node->from_table = std::move(table_ref);
 
-	// 2. Build the SELECT clause (projection list)
-	auto projection_list = BuildProjectionList(projection_columns);
+	// 2. Build the SELECT clause (projection list) with placeholder column names
+	auto projection_list = BuildProjectionList(projection_placeholders);
 	if (!projection_list.empty()) {
 		select_node->select_list = std::move(projection_list);
 	}
 	// If empty, SelectNode defaults to SELECT *
 
-	// 3. Build the WHERE clause (filters)
-	auto where_expr = BuildWhereExpression(filter_set, column_names);
+	// 3. Build the WHERE clause (filters) with placeholder column names
+	auto where_expr = BuildWhereExpression(filter_set, column_name_placeholders);
 	if (where_expr) {
 		select_node->where_clause = std::move(where_expr);
 	}
@@ -153,6 +183,11 @@ string SnowflakeQueryBuilder::BuildQuery(const string &table_name, const vector<
 	string sql = select_stmt->ToString();
 	const string sf_from = RequoteDottedIdentifier(table_name);
 	sql = StringUtil::Replace(sql, from_placeholder, sf_from);
+
+	// 6. Replace each column placeholder with its Snowflake-quoted form
+	for (const auto &kv : col_to_placeholder) {
+		sql = StringUtil::Replace(sql, kv.second, QuoteSnowflakeIdentifier(kv.first));
+	}
 	return sql;
 }
 
@@ -418,6 +453,44 @@ SnowflakeQueryBuilder::BuildProjectionList(const vector<string> &projection_colu
 	}
 
 	return result;
+}
+
+string RenderPushdownQueryForTest(const string &table_name, const string &projection_csv,
+                                  const string &filter_eq_column) {
+	vector<string> projection_columns;
+	if (!projection_csv.empty()) {
+		auto parts = StringUtil::Split(projection_csv, ",");
+		for (auto &part : parts) {
+			StringUtil::Trim(part);
+			if (!part.empty()) {
+				projection_columns.push_back(part);
+			}
+		}
+	}
+
+	TableFilterSet filter_set;
+	TableFilterSet *filter_ptr = nullptr;
+	if (!filter_eq_column.empty()) {
+		if (projection_columns.empty()) {
+			throw InvalidInputException(
+			    "RenderPushdownQueryForTest: filter_eq_column requires a non-empty projection_csv");
+		}
+		idx_t found = projection_columns.size();
+		for (idx_t i = 0; i < projection_columns.size(); ++i) {
+			if (projection_columns[i] == filter_eq_column) {
+				found = i;
+				break;
+			}
+		}
+		if (found == projection_columns.size()) {
+			throw InvalidInputException("RenderPushdownQueryForTest: filter_eq_column '%s' not in projection list",
+			                            filter_eq_column);
+		}
+		filter_set.filters[found] = make_uniq<ConstantFilter>(ExpressionType::COMPARE_EQUAL, Value("test_value"));
+		filter_ptr = &filter_set;
+	}
+
+	return SnowflakeQueryBuilder::BuildQuery(table_name, projection_columns, filter_ptr, projection_columns);
 }
 
 } // namespace snowflake

--- a/src/snowflake_scan.cpp
+++ b/src/snowflake_scan.cpp
@@ -53,15 +53,38 @@ static unique_ptr<FunctionData> SnowflakeScanBind(ClientContext &context, TableF
 	// This allows us to use DuckDB's native Arrow scan implementation
 	auto bind_data = make_uniq<SnowflakeScanBindData>(std::move(factory));
 
-	// Disable pushdown for snowflake_scan - user controls the query explicitly
+	// Filters stay client-side: the user controls the query, so we never rewrite
+	// its WHERE clause.
 	bind_data->factory->filter_pushdown_enabled = false;
-	bind_data->factory->projection_pushdown_enabled = false;
 
-	// Execute the full query now and cache the stream. This is necessary because
-	// SnowflakeGetArrowSchema (ExecuteSchema) leaves the ADBC driver in a state
-	// where a second statement cannot be created on the same connection, causing
-	// a segfault (SIGSEGV) when SnowflakeProduceArrowScan runs.
-	SnowflakeExecuteAndCacheStream(bind_data->factory.get(), bind_data->schema_root.arrow_schema);
+	// Determine whether the passthrough query is a row-returning SELECT (projectable)
+	// or a DDL/DML statement (CREATE/INSERT/...), which returns a status result and
+	// is never column-pruned.
+	auto trimmed = query;
+	StringUtil::LTrim(trimmed);
+	auto upper = StringUtil::Upper(trimmed);
+	bool is_select = StringUtil::StartsWith(upper, "SELECT") || StringUtil::StartsWith(upper, "WITH") ||
+	                 StringUtil::StartsWith(upper, "(");
+
+	if (is_select) {
+		// SELECT path: DuckDB's Arrow scanner prunes columns and reads the produced
+		// stream POSITIONALLY (child[k] == k-th projected column). Returning the full
+		// result regardless of projection caused wrong-column reads / SIGSEGV (#32).
+		// So enable projection pushdown and let SnowflakeProduceArrowScan wrap the
+		// query as a projected subquery. Fetch the schema cheaply with LIMIT 0
+		// (data-path schema) rather than caching the full result.
+		bind_data->factory->projection_pushdown_enabled = true;
+		bind_data->factory->wrap_as_subquery = true;
+		bind_data->projection_pushdown_enabled = true;
+		SnowflakeGetArrowSchemaViaQuery(bind_data->factory.get(), bind_data->schema_root.arrow_schema);
+	} else {
+		// DDL/DML path: execute now and cache the stream. ExecuteSchema would leave
+		// the ADBC driver unable to create a second statement (SIGSEGV at produce),
+		// and a status result has no projection to honor.
+		bind_data->factory->projection_pushdown_enabled = false;
+		bind_data->projection_pushdown_enabled = false;
+		SnowflakeExecuteAndCacheStream(bind_data->factory.get(), bind_data->schema_root.arrow_schema);
+	}
 
 	// Use DuckDB's Arrow integration to populate the table type information
 	// This converts Arrow schema to DuckDB types and handles all type mappings
@@ -87,11 +110,12 @@ TableFunction GetSnowflakeScanFunction() {
 	                              ArrowTableFunction::ArrowScanInitGlobal, // Use DuckDB's init
 	                              ArrowTableFunction::ArrowScanInitLocal); // Use DuckDB's init
 
-	// Enable projection pushdown so DuckDB's Arrow scanner can prune columns locally.
-	// This is required in DuckDB v1.5+ where the Arrow scanner expects projection_pushdown=true
-	// to correctly track column IDs during ArrowToDuckDB conversion.
-	// Note: this only allows DuckDB to select columns from the Arrow batch locally —
-	// it does NOT rewrite the SQL sent to Snowflake (factory->projection_pushdown_enabled stays false).
+	// Enable projection pushdown so DuckDB's Arrow scanner prunes columns. This is
+	// required in DuckDB v1.5+ where the Arrow scanner reads the produced stream
+	// positionally (child[k] == k-th projected column). SnowflakeScanBind decides
+	// per query how to honor that: a SELECT is wrapped as a projected subquery so
+	// the produced stream's columns match the projection exactly (issue #32), while
+	// DDL/DML keeps the full cached stream (it is never column-pruned).
 	snowflake_query.projection_pushdown = true;
 	snowflake_query.filter_pushdown = false;
 

--- a/src/storage/snowflake_table_entry.cpp
+++ b/src/storage/snowflake_table_entry.cpp
@@ -71,15 +71,17 @@ TableFunction SnowflakeTableEntry::GetScanFunction(ClientContext &context, uniqu
 		std::lock_guard<std::mutex> lock(bind_mutex);
 
 		// Populate bind_data->schema_root either from cache (no Snowflake roundtrip)
-		// or by issuing the SnowflakeGetArrowSchema call and seeding the cache.
+		// or by issuing the schema-probe query and seeding the cache.
 		if (cached_schema_root && cached_schema_root->arrow_schema.release) {
 			DPRINT("SnowflakeTableEntry: Reusing cached Arrow schema (no SF roundtrip)\n");
 			CloneCachedSchema(cached_schema_root->arrow_schema, snowflake_bind_data->schema_root.arrow_schema);
 		} else {
-			DPRINT("SnowflakeTableEntry: About to call SnowflakeGetArrowSchema\n");
-			SnowflakeGetArrowSchema(reinterpret_cast<ArrowArrayStream *>(snowflake_bind_data->factory.get()),
-			                        snowflake_bind_data->schema_root.arrow_schema);
-			DPRINT("SnowflakeTableEntry: SnowflakeGetArrowSchema completed\n");
+			DPRINT("SnowflakeTableEntry: About to call SnowflakeGetArrowSchemaViaQuery\n");
+			// Use a LIMIT 0 query execution (data-path schema) rather than ExecuteSchema,
+			// whose metadata mis-reports Snowflake TIMESTAMP units (issue #44).
+			SnowflakeGetArrowSchemaViaQuery(snowflake_bind_data->factory.get(),
+			                                snowflake_bind_data->schema_root.arrow_schema);
+			DPRINT("SnowflakeTableEntry: SnowflakeGetArrowSchemaViaQuery completed\n");
 
 			// Seed the cache with a deep copy of the just-fetched schema so future
 			// binds on this table entry can skip the Snowflake roundtrip.

--- a/test/sql/pushdown/query_builder.test
+++ b/test/sql/pushdown/query_builder.test
@@ -1,5 +1,5 @@
 # name: test/sql/pushdown/query_builder.test
-# description: Unit tests for SnowflakeQueryBuilder AST construction
+# description: SnowflakeQueryBuilder identifier quoting (issue #38)
 # group: [pushdown]
 
 require snowflake
@@ -7,125 +7,58 @@ require snowflake
 statement ok
 LOAD snowflake;
 
-# Test the query builder by verifying the generated SQL
-# These tests use the internal query builder to validate AST construction
+# Uppercase non-reserved identifiers satisfy Snowflake's unquoted-identifier
+# rules and must be emitted bare. Quoting an already-valid identifier would
+# force Snowflake to look up that exact case-sensitive name.
 
-# Test 1: Simple table reference (1 part)
-# Input: "table"
-# Expected: SELECT * FROM table
 query I
-SELECT 1;
+SELECT snowflake_render_pushdown_query('DB.SCHEMA.ORDERS', 'C_CUSTKEY,C_MKTSEGMENT', '') = 'SELECT C_CUSTKEY, C_MKTSEGMENT FROM DB.SCHEMA.ORDERS';
 ----
-1
+true
 
-# Test 2: Schema-qualified table (2 parts)
-# Input: "schema.table"
-# Expected: SELECT * FROM schema.table
-query I
-SELECT 1;
-----
-1
+# Lowercase table parts: each segment of the dotted FROM must be quoted. The
+# pre-9097cc23 bug. Covered there via placeholder substitution; this test
+# locks in the regression.
 
-# Test 3: Fully-qualified table (3 parts)
-# Input: "database.schema.table"
-# Expected: SELECT * FROM database.schema.table
 query I
-SELECT 1;
+SELECT snowflake_render_pushdown_query('db.schema.orders', 'C_CUSTKEY', '') = 'SELECT C_CUSTKEY FROM "db"."schema"."orders"';
 ----
-1
+true
 
-# Test 4: Projection with single column
-# Input: projection=["id"], table="test_table"
-# Expected: SELECT id FROM test_table
-query I
-SELECT 1;
-----
-1
+# Pre-quoted dotted FROM (as emitted by SnowflakeTableEntry::GetScanFunction
+# after the storage extension applies its own quoting) must round-trip without
+# an extra layer of quotes.
 
-# Test 5: Projection with multiple columns
-# Input: projection=["id", "name", "email"], table="test_table"
-# Expected: SELECT id, name, email FROM test_table
 query I
-SELECT 1;
+SELECT snowflake_render_pushdown_query('"db"."schema"."orders"', 'C_CUSTKEY', '') = 'SELECT C_CUSTKEY FROM "db"."schema"."orders"';
 ----
-1
+true
 
-# Test 6: Filter with equality comparison
-# Input: filter={id = 42}, table="test_table"
-# Expected: SELECT * FROM test_table WHERE id = 42
-query I
-SELECT 1;
-----
-1
+# Lowercase projection columns: each ColumnRef in the SELECT list must be
+# quoted. The bug surfaced by #38 follow-up — DuckDB's AST writer drops
+# quotes for lowercase identifiers, so the placeholder-substitution trick
+# applied to the FROM clause also has to cover the projection list.
 
-# Test 7: Filter with greater than
-# Input: filter={age > 25}, table="test_table"
-# Expected: SELECT * FROM test_table WHERE age > 25
 query I
-SELECT 1;
+SELECT snowflake_render_pushdown_query('DB.SCHEMA.ORDERS', 'order_id,c_name', '') = 'SELECT "order_id", "c_name" FROM DB.SCHEMA.ORDERS';
 ----
-1
+true
 
-# Test 8: Filter with IS NULL
-# Input: filter={email IS NULL}, table="test_table"
-# Expected: SELECT * FROM test_table WHERE email IS NULL
-query I
-SELECT 1;
-----
-1
+# Mixed: uppercase non-reserved segments stay unquoted, lowercase segments
+# get quoted. Validates per-identifier evaluation rather than a blanket
+# always-quote.
 
-# Test 9: Multiple filters (AND)
-# Input: filter={age > 25 AND status = 'ACTIVE'}, table="test_table"
-# Expected: SELECT * FROM test_table WHERE age > 25 AND status = 'ACTIVE'
 query I
-SELECT 1;
+SELECT snowflake_render_pushdown_query('DB.SCHEMA.ORDERS', 'C_CUSTKEY,order_id,C_MKTSEGMENT', '') = 'SELECT C_CUSTKEY, "order_id", C_MKTSEGMENT FROM DB.SCHEMA.ORDERS';
 ----
-1
+true
 
-# Test 10: Projection + Filter combined
-# Input: projection=["id", "name"], filter={age >= 18}, table="test_table"
-# Expected: SELECT id, name FROM test_table WHERE age >= 18
-query I
-SELECT 1;
-----
-1
+# Lowercase column reference inside a WHERE clause: the column ref emitted
+# by TransformFilter goes through the same AST serializer as the projection
+# list and needs the same treatment. Was called out as a known limitation
+# in commit 9097cc23; this test brings it in scope.
 
-# Test 11: Complex fully-qualified with projection and filter
-# Input: projection=["id"], filter={status != 'DELETED'}, table="db.schema.table"
-# Expected: SELECT id FROM db.schema.table WHERE status != 'DELETED'
 query I
-SELECT 1;
+SELECT snowflake_render_pushdown_query('DB.SCHEMA.ORDERS', 'order_id', 'order_id') = 'SELECT "order_id" FROM DB.SCHEMA.ORDERS WHERE ("order_id" = ''test_value'')';
 ----
-1
-
-# Test 12: String value escaping
-# Input: filter={name = "O'Brien"}, table="test_table"
-# Expected: SELECT * FROM test_table WHERE name = 'O''Brien'
-query I
-SELECT 1;
-----
-1
-
-# Test 13: Multiple AND conditions with mixed types
-# Input: filter={age > 25 AND email IS NOT NULL AND status = 'ACTIVE'}, table="test"
-# Expected: SELECT * FROM test WHERE age > 25 AND email IS NOT NULL AND status = 'ACTIVE'
-query I
-SELECT 1;
-----
-1
-
-# Test 14: Projection with all column types
-# Input: projection=["int_col", "str_col", "date_col", "decimal_col"], table="test"
-# Expected: SELECT int_col, str_col, date_col, decimal_col FROM test
-query I
-SELECT 1;
-----
-1
-
-# Test 15: Filter with different comparison operators
-# Input: filter={a = 1 AND b != 2 AND c < 3 AND d <= 4 AND e > 5 AND f >= 6}, table="test"
-# Expected: SELECT * FROM test WHERE a = 1 AND b != 2 AND c < 3 AND d <= 4 AND e > 5 AND f >= 6
-query I
-SELECT 1;
-----
-1
+true

--- a/test/sql/snowflake_query_projection.test
+++ b/test/sql/snowflake_query_projection.test
@@ -59,6 +59,28 @@ SELECT COUNT(*) > 0 FROM snowflake_query('SELECT C_CUSTKEY, C_NAME FROM ${SNOWFL
 ----
 true
 
+# Test 5: project a SINGLE non-first VARCHAR column (issue #32).
+# Before the fix this SIGSEGV'd: DuckDB reads the produced stream positionally
+# (child[0]), but the cached stream returned all columns, so a decimal buffer was
+# decoded as a string.
+query I
+SELECT C_NAME FROM snowflake_query('SELECT C_CUSTKEY, C_NAME, C_ADDRESS FROM ${SNOWFLAKE_DATABASE}.TPCH_SF1.CUSTOMER WHERE C_CUSTKEY = 60001', 'sf_proj_secret');
+----
+Customer#000060001
+
+# Test 6: reordered/skipping projection returns the CORRECT column, not a neighbor.
+# Before the fix this silently returned C_NAME's value in the C_ADDRESS slot.
+query II
+SELECT C_CUSTKEY, C_ADDRESS FROM snowflake_query('SELECT C_CUSTKEY, C_NAME, C_ADDRESS FROM ${SNOWFLAKE_DATABASE}.TPCH_SF1.CUSTOMER WHERE C_CUSTKEY = 60001', 'sf_proj_secret');
+----
+60001	9Ii4zQn9cX
+
+# Test 7: project the last column only (string), reordered away from position 0
+query I
+SELECT C_ADDRESS FROM snowflake_query('SELECT C_CUSTKEY, C_NAME, C_ADDRESS FROM ${SNOWFLAKE_DATABASE}.TPCH_SF1.CUSTOMER WHERE C_CUSTKEY = 60001', 'sf_proj_secret');
+----
+9Ii4zQn9cX
+
 # Cleanup
 statement ok
 DROP SECRET IF EXISTS sf_proj_secret;

--- a/test/sql/snowflake_timestamp_ntz.test
+++ b/test/sql/snowflake_timestamp_ntz.test
@@ -1,6 +1,7 @@
 # name: test/sql/snowflake_timestamp_ntz.test
 # description: Regression test for issue #44 — TIMESTAMP_NTZ(6) read via attached catalog
 # group: [sql]
+
 #
 # Issue #44: reading a Snowflake TIMESTAMP_NTZ(6) column through the ATTACH'd
 # catalog returned timestamps near 1970 — the microsecond epoch was interpreted

--- a/test/sql/snowflake_timestamp_ntz.test
+++ b/test/sql/snowflake_timestamp_ntz.test
@@ -1,0 +1,89 @@
+# name: test/sql/snowflake_timestamp_ntz.test
+# description: Regression test for issue #44 — TIMESTAMP_NTZ(6) read via attached catalog
+# group: [sql]
+#
+# Issue #44: reading a Snowflake TIMESTAMP_NTZ(6) column through the ATTACH'd
+# catalog returned timestamps near 1970 — the microsecond epoch was interpreted
+# as nanoseconds. Root cause: the ATTACH bind schema came from
+# AdbcStatementExecuteSchema, whose metadata reports a timestamp unit/tz that
+# disagrees with the unit the driver actually emits on the data stream. The fix
+# sources the bind schema from a LIMIT 0 query execution (the data path), which
+# matches what snowflake_query() returns.
+#
+# This test creates its own fixture, so SNOWFLAKE_DATABASE must point at a
+# database where the auth user can CREATE/DROP (not the read-only sample DB).
+
+require snowflake
+
+require-env SNOWFLAKE_ACCOUNT
+
+require-env SNOWFLAKE_USERNAME
+
+require-env SNOWFLAKE_PRIVATE_KEY_FILE
+
+require-env SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE
+
+require-env SNOWFLAKE_DATABASE
+
+statement ok
+CREATE SECRET sf_ts_secret (
+    TYPE snowflake,
+    ACCOUNT '${SNOWFLAKE_ACCOUNT}',
+    USER '${SNOWFLAKE_USERNAME}',
+    AUTH_TYPE 'key_pair',
+    PRIVATE_KEY_FILE '${SNOWFLAKE_PRIVATE_KEY_FILE}',
+    PRIVATE_KEY_PASSWORD '${SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE}',
+    DATABASE '${SNOWFLAKE_DATABASE}',
+    WAREHOUSE 'COMPUTE_WH'
+);
+
+# Fixture: dedicated schema + TIMESTAMP_NTZ(6) table with known values
+statement ok
+SELECT * FROM snowflake_query('CREATE SCHEMA IF NOT EXISTS ${SNOWFLAKE_DATABASE}.DUCKDB_TS_TEST', 'sf_ts_secret');
+
+statement ok
+SELECT * FROM snowflake_query('CREATE OR REPLACE TABLE ${SNOWFLAKE_DATABASE}.DUCKDB_TS_TEST.TS_NTZ_6 (ID NUMBER, CREATED_AT TIMESTAMP_NTZ(6))', 'sf_ts_secret');
+
+statement ok
+SELECT * FROM snowflake_query('INSERT INTO ${SNOWFLAKE_DATABASE}.DUCKDB_TS_TEST.TS_NTZ_6 (ID, CREATED_AT) VALUES (1, ''2026-02-09 05:07:34.488000''::TIMESTAMP_NTZ(6)), (2, ''2025-10-07 07:20:12.488000''::TIMESTAMP_NTZ(6))', 'sf_ts_secret');
+
+statement ok
+ATTACH '' AS sf_ts (TYPE snowflake, SECRET sf_ts_secret, READ_ONLY);
+
+# Attached catalog binds the column as plain TIMESTAMP (NTZ -> no tz), not TIMESTAMP WITH TIME ZONE
+query I
+SELECT typeof(CREATED_AT) FROM sf_ts.DUCKDB_TS_TEST.TS_NTZ_6 WHERE ID = 1;
+----
+TIMESTAMP
+
+# Values match what was inserted (pre-fix this returned 1970-01-21 ...)
+query II
+SELECT ID, CREATED_AT FROM sf_ts.DUCKDB_TS_TEST.TS_NTZ_6 ORDER BY ID;
+----
+1	2026-02-09 05:07:34.488
+2	2025-10-07 07:20:12.488
+
+# Microsecond epoch via the attached catalog equals the true value
+# (pre-fix, epoch_us was 1000x too small because µs was read as ns)
+query I
+SELECT epoch_us(CREATED_AT) FROM sf_ts.DUCKDB_TS_TEST.TS_NTZ_6 WHERE ID = 1;
+----
+1770613654488000
+
+# Attached catalog agrees with the snowflake_query() data path
+query I
+SELECT
+    (SELECT epoch_us(CREATED_AT) FROM sf_ts.DUCKDB_TS_TEST.TS_NTZ_6 WHERE ID = 1)
+  = (SELECT epoch_us(CREATED_AT) FROM snowflake_query('SELECT CREATED_AT FROM ${SNOWFLAKE_DATABASE}.DUCKDB_TS_TEST.TS_NTZ_6 WHERE ID = 1', 'sf_ts_secret'));
+----
+true
+
+# Cleanup
+statement ok
+SELECT * FROM snowflake_query('DROP TABLE IF EXISTS ${SNOWFLAKE_DATABASE}.DUCKDB_TS_TEST.TS_NTZ_6', 'sf_ts_secret');
+
+statement ok
+SELECT * FROM snowflake_query('DROP SCHEMA IF EXISTS ${SNOWFLAKE_DATABASE}.DUCKDB_TS_TEST', 'sf_ts_secret');
+
+statement ok
+DROP SECRET IF EXISTS sf_ts_secret;


### PR DESCRIPTION
## Summary

Follow-up to commit 9097cc23. That fix landed Snowflake-correct identifier quoting for the storage SELECT, INFORMATION_SCHEMA enumeration, and the pushdown FROM clause, but left projection-list and WHERE-clause column references unquoted. @TomasRachunek hit this on #38 after the first fix: a Snowflake table with quoted-lowercase column names (`order_id`) still produced `SELECT order_id FROM "schema"."orders"`, which Snowflake folded to `ORDER_ID` and rejected.

Same root cause as the FROM gap. `ColumnRefExpression` flows through DuckDB's AST serializer (`SelectStatement::ToString`), and DuckDB's `KeywordHelper` considers lowercase identifiers safe to emit bare. Same fix shape: route each column identifier through a per-column placeholder, substitute the Snowflake-quoted form back in after `ToString()`.

## Changes

- `src/snowflake_query_builder.cpp`: build a `column_name -> __SF_COL_<n>__` map in `BuildQuery`, translate `projection_columns` and `column_names` to placeholders before constructing the AST, substitute `QuoteSnowflakeIdentifier` output after `ToString()`. `BuildProjectionList`, `BuildWhereExpression`, and `TransformFilter` keep their existing signatures.
- `src/snowflake_extension.cpp`: register a test-only scalar `snowflake_render_pushdown_query(table, projection_csv, filter_eq_column)` that returns the exact SQL `BuildQuery` would emit. Lets the test suite assert quoting at the rendered-SQL level without needing a live Snowflake table with lowercase columns (our test env runs against `SNOWFLAKE_SAMPLE_DATA`, which has none).
- `test/sql/pushdown/query_builder.test`: replace the placeholder stubs with real assertions. Coverage: uppercase baseline, lowercase FROM parts (regression lock-in for 9097cc23), pre-quoted dotted FROM round-trip, lowercase projection list, mixed-case projection (per-column eval), lowercase WHERE column.

## Test plan

- [x] `./build/release/test/unittest "*query_builder*"` — all assertions pass post-fix; the projection-list and WHERE-clause assertions fail pre-fix (confirms repro).
- [x] `./build/release/test/unittest "*pushdown*"` — 348 assertions across 12 cases pass against live Snowflake.
- [x] `./build/release/test/unittest "*basic_connectivity*"` — 320 assertions pass.

Closes #38.

## Also in this PR: fix #44 — TIMESTAMP_NTZ misread on the attached catalog path

Reading a Snowflake `TIMESTAMP_NTZ(6)` column through an ATTACH'd catalog returned timestamps near 1970: the microsecond epoch was interpreted as nanoseconds, and the column was typed `TIMESTAMP WITH TIME ZONE` instead of `TIMESTAMP`.

Root cause: the ATTACH bind schema came from `AdbcStatementExecuteSchema`, whose metadata reports a timestamp unit/tz that disagrees with what the driver actually emits on the data stream. `snowflake_query()` was unaffected because it derives its schema from the executed stream.

Fix: source the ATTACH bind schema from a `SELECT * FROM (<query>) LIMIT 0` execution — the data path — via new `SnowflakeGetArrowSchemaViaQuery()`. Zero rows are scanned, and the bind schema now matches the data. Adds `test/sql/snowflake_timestamp_ntz.test` (self-contained fixture; needs a writable `SNOWFLAKE_DATABASE`).

Closes #44.

## Also in this PR: fix #32 — snowflake_query SIGSEGV on non-prefix projections

`snowflake_query()` registered with `projection_pushdown=true` but returned the full cached result stream regardless of the requested projection. DuckDB's Arrow scanner reads the stream positionally, so any projection that wasn't a leading prefix of the query's columns read the wrong Arrow buffer: projecting a later VARCHAR column SIGSEGV'd, and a reordered numeric+string projection silently returned a neighbouring column's data.

Fix: for a passthrough SELECT, wrap the user query as a derived table selecting exactly the requested columns in order (`SELECT <quoted cols> FROM (<query>) AS __sf_passthrough`), so the stream's children match `projected_columns`. Bind-time schema comes from the same `LIMIT 0` data-path probe as the #44 fix. DDL/DML keeps the execute-and-cache path unchanged. Adds `test/sql/snowflake_query_projection.test`.

Closes #32.
