### PR TITLE
chore: repo hygiene + docs polish

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,48 @@
+---
+name: Bug report
+about: Something is broken or behaves unexpectedly
+title: ''
+labels: bug, needs-repro
+assignees: ''
+---
+
+## What happened
+
+<!-- A clear, specific description. Paste the error message verbatim if there is one. -->
+
+## What you expected
+
+<!-- What should have happened instead. -->
+
+## Reproduction
+
+<!-- Minimal SQL that reproduces the issue. If the repro requires specific
+     table contents, describe the shape (column types, row counts). -->
+
+```sql
+-- Your repro here
+```
+
+## Environment
+
+- **Extension version** (`SELECT snowflake_version();`):
+- **DuckDB version** (`PRAGMA version;`):
+- **OS / architecture** (e.g. macOS 14 arm64, Ubuntu 22.04 x86_64):
+- **Install method** (community-extensions registry, built from source, packaged zip):
+- **ADBC Snowflake driver version** (path + how you installed it):
+- **Snowflake authentication method** (password, key pair, OAuth, EXT_BROWSER, Okta, MFA):
+- **Snowflake region / cloud** if relevant:
+
+## Logs / debug output
+
+<!-- If you have it: query plan (EXPLAIN), debug output, anything from
+     the extension's [DEBUG] lines, stack trace, etc. -->
+
+```
+paste output here
+```
+
+## Additional context
+
+<!-- Anything else worth knowing — workarounds tried, when this started,
+     related issues. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/iqea-ai/duckdb-snowflake/security/policy
+    about: Please report security issues privately — see SECURITY.md.
+  - name: DuckDB core question
+    url: https://github.com/duckdb/duckdb/discussions
+    about: Questions about DuckDB itself (not the Snowflake extension) belong upstream.
+  - name: ADBC Snowflake driver issue
+    url: https://github.com/adbc-drivers/snowflake/issues
+    about: Bugs in the ADBC Snowflake driver itself should be filed upstream.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature request
+about: Suggest a capability the extension doesn't have today
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+<!-- What are you trying to do that you can't do today? Concrete use case,
+     not just a capability list. -->
+
+## Proposed behavior
+
+<!-- What you'd like the extension to do. If you have an idea about the
+     SQL surface (function signature, ATTACH option, secret field, etc.),
+     include it. -->
+
+## Alternatives considered
+
+<!-- What workarounds have you tried? Why aren't they enough? -->
+
+## Scope / blast radius
+
+<!-- Does this belong in this repo (the DuckDB extension), upstream in
+     the ADBC Snowflake driver, or upstream in DuckDB core itself? If
+     you're not sure, that's fine — note it. -->
+
+## Additional context
+
+<!-- Anything else: prior art in other DuckDB extensions, links to
+     Snowflake docs, performance numbers, etc. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,38 @@
+---
+name: Question / usage help
+about: How do I do X with the Snowflake extension?
+title: ''
+labels: question
+assignees: ''
+---
+
+## What you're trying to do
+
+<!-- Describe the end goal, not just the immediate step. We can usually
+     give a better answer when we understand the workflow. -->
+
+## What you've tried
+
+```sql
+-- SQL you've run, or the closest you got
+```
+
+## What you saw
+
+<!-- Error message, unexpected result, surprising performance — paste it. -->
+
+## Environment
+
+- **Extension version** (`SELECT snowflake_version();`):
+- **DuckDB version** (`PRAGMA version;`):
+- **OS / architecture**:
+- **Snowflake authentication method**:
+
+## Already-checked references
+
+<!-- Help us avoid sending you back to docs you've already read.
+     - [ ] README.md
+     - [ ] docs/AUTHENTICATION.md
+     - [ ] docs/AUTHENTICATION_SETUP.md
+     - [ ] BUILD.md
+     - [ ] Existing closed issues -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!--
+Thanks for the PR. A few asks to keep the review fast:
+- Scope this PR to one logical change. Bundles are the exception, not the rule.
+- Make sure the live-Snowflake test workflow passed (or note why it didn't).
+- Keep CHANGELOG.md up to date — add an entry under the unreleased section.
+-->
+
+## Summary
+
+<!-- One paragraph: what does this change, and why. -->
+
+## Related issues
+
+<!-- "Closes #N" for any issue this fully resolves; "Refs #N" otherwise. -->
+
+## Type of change
+
+<!-- Check one. -->
+- [ ] Bug fix
+- [ ] New feature / enhancement
+- [ ] Documentation only
+- [ ] Build, CI, or repo tooling
+- [ ] DuckDB version bump
+
+## Testing
+
+<!--
+Describe what you ran. For changes that touch the query path, please include
+results from both:
+  ./build/release/test/unittest "*snowflake_*"
+  ./build/release/test/unittest "[pushdown]"
+If you couldn't run the live-Snowflake suite locally, say so explicitly.
+-->
+
+## Checklist
+
+- [ ] Code formatted with `python3 duckdb/scripts/format.py <changed-files>` (or `make format-fix`).
+- [ ] `CHANGELOG.md` updated if user-visible behavior changed.
+- [ ] Docs (`README.md`, `BUILD.md`, `docs/`) updated if relevant.
+- [ ] No `Co-Authored-By:` trailers for tools or AI assistants.

--- a/BUILD.md
+++ b/BUILD.md
@@ -151,7 +151,7 @@ CREATE SECRET test_snowflake (
 query I
 SELECT snowflake_version();
 ----
-Snowflake Extension v0.1.0
+Snowflake Extension v0.4.1
 ```
 
 ### Integration Testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The version recorded here is the **extension version** (what `snowflake_version()`
+returns and what the [community-extensions descriptor](https://github.com/duckdb/community-extensions/blob/main/extensions/snowflake/description.yml)
+pins). The DuckDB version each release targets is noted separately.
+
+## [0.4.1] - 2026-06-04
+
+Targets DuckDB **v1.5.3**.
+
+### Changed
+- Update DuckDB submodule to v1.5.3 ([#39](https://github.com/iqea-ai/duckdb-snowflake/pull/39))
+
+### Fixed
+- Pass password to ADBC driver for Okta native authentication ([#34](https://github.com/iqea-ai/duckdb-snowflake/pull/34), Setzer)
+- Use the correct ADBC key for database and make `DATABASE` optional on `CREATE SECRET` ([#35](https://github.com/iqea-ai/duckdb-snowflake/pull/35), Setzer)
+- `SnowflakeSecret::Validate()` no longer requires a password for `ext_browser`/`externalbrowser` auth ([#37](https://github.com/iqea-ai/duckdb-snowflake/issues/37), in [#40](https://github.com/iqea-ai/duckdb-snowflake/pull/40))
+- Quote Snowflake identifiers in storage SELECT, INFORMATION_SCHEMA enumeration, and the pushdown `FROM` clause so unquoted identifiers don't fold to uppercase ([#38](https://github.com/iqea-ai/duckdb-snowflake/issues/38), in [#40](https://github.com/iqea-ai/duckdb-snowflake/pull/40))
+- Persistent Snowflake secrets deserialized at session start before the extension loads now resolve correctly via `KeyValueSecret::TryGetValue` instead of failing the typed cast ([#36](https://github.com/iqea-ai/duckdb-snowflake/issues/36), in [#40](https://github.com/iqea-ai/duckdb-snowflake/pull/40))
+- Cache the Arrow schema on `SnowflakeTableEntry` to avoid 300–500ms per-bind round-trips on `CREATE VIEW` and similar paths ([#33](https://github.com/iqea-ai/duckdb-snowflake/issues/33), in [#40](https://github.com/iqea-ai/duckdb-snowflake/pull/40))
+
+### Security
+- Restrict workflow `GITHUB_TOKEN` permissions to `contents: read` on the three Main Distribution Pipeline jobs ([#41](https://github.com/iqea-ai/duckdb-snowflake/pull/41))
+
+## [0.4.0] - 2026-04-20
+
+Targets DuckDB **v1.5.2**. First release distributed via the DuckDB community-extensions registry under this version line.
+
+### Changed
+- Update DuckDB submodule to v1.5.2 ([#31](https://github.com/iqea-ai/duckdb-snowflake/pull/31))
+- Switch the live-Snowflake test suite from password to key-pair authentication
+
+### Fixed
+- ADBC option keys for OAuth token, Okta URL, and keep-alive ([#30](https://github.com/iqea-ai/duckdb-snowflake/pull/30))
+- PEM parsing regression ([#26](https://github.com/iqea-ai/duckdb-snowflake/issues/26)) and `snowflake_query` segfault ([#21](https://github.com/iqea-ai/duckdb-snowflake/issues/21)), both addressed in [#27](https://github.com/iqea-ai/duckdb-snowflake/pull/27)
+
+## [Earlier]
+
+Earlier releases predate this CHANGELOG and the version-to-release mapping below is reconstructed from git history. The version numbers used by the community-extensions descriptor for these merges are not recorded in this repository — TODO: recover from `duckdb/community-extensions` history if needed.
+
+- 2026-03-20 — Fix `snowflake_query` crash on column-pruning queries with DuckDB v1.5 ([#25](https://github.com/iqea-ai/duckdb-snowflake/pull/25))
+- 2026-03-13 — Update extension for DuckDB v1.5 compatibility ([#23](https://github.com/iqea-ai/duckdb-snowflake/pull/23))
+
+[0.4.1]: https://github.com/iqea-ai/duckdb-snowflake/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/iqea-ai/duckdb-snowflake/releases/tag/v0.4.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,156 @@
+# Contributing to duckdb-snowflake
+
+Thanks for your interest in contributing. This document covers the working
+agreement: how to build, how to run the tests (including the live-Snowflake
+suite), and what we expect on PRs.
+
+For the longer-form developer guide (toolchain prerequisites, platform notes,
+internal architecture), see [BUILD.md](BUILD.md).
+
+## Build
+
+The repo uses the DuckDB extension build harness via `extension-ci-tools`.
+
+```bash
+# Clone with submodules
+git clone --recurse-submodules https://github.com/iqea-ai/duckdb-snowflake.git
+cd duckdb-snowflake
+
+# Release build (downloads the Snowflake ADBC driver on first run if missing)
+make release
+
+# Debug build
+make debug
+```
+
+The Makefile fetches `adbc_drivers/libadbc_driver_snowflake.so` via
+`scripts/download_adbc_driver.sh` if it isn't already present. You don't
+normally need to manage that file yourself.
+
+## Test suites
+
+There are two layers of tests:
+
+1. **Build-only smoke tests** that ship with the DuckDB extension harness and
+   run in CI as `Main Extension Distribution Pipeline`.
+2. **Live-Snowflake integration tests** under `test/sql/` that connect to a
+   real Snowflake account. These require credentials and run in a separate
+   workflow (`Test with Snowflake`).
+
+### Running the live-Snowflake suite locally
+
+You need a Snowflake account with access to the TPC-H sample data
+(`SNOWFLAKE_SAMPLE_DATA.TPCH_SF1`), the ADBC Snowflake driver installed
+locally, and an RSA key pair registered against your user.
+
+Set the following environment variables before running the tests:
+
+| Variable | Purpose |
+| --- | --- |
+| `SNOWFLAKE_ACCOUNT` | Snowflake account identifier (short form, e.g. `xy12345.us-east-1`). |
+| `SNOWFLAKE_DATABASE` | Database to run against (e.g. `SNOWFLAKE_SAMPLE_DATA`). |
+| `SNOWFLAKE_USERNAME` | User for the password/key-pair tests under `test/sql/snowflake_*.test` that use the `USERNAME`-named secret form. |
+| `SNOWFLAKE_PRIVATE_KEY_FILE` | Path to the RSA private key PEM file, used by `snowflake_basic_connectivity`, `snowflake_data_types`, `snowflake_read_operations`, `snowflake_performance`, `snowflake_error_handling`. |
+| `SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE` | Path to a file containing the passphrase for the private key above. |
+| `SNOWFLAKE_KEYPAIR_USER` | User for the pushdown and projection tests, which create their own keypair secret. |
+| `SNOWFLAKE_PRIVATE_KEY_PATH` | Path to the RSA private key PEM file, used by `test/sql/pushdown/*.test` and `snowflake_query_projection.test`. |
+| `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE` | Passphrase value (not file) for the key above. |
+| `SNOWFLAKE_ADBC_DRIVER_PATH` | Absolute path to `libadbc_driver_snowflake.so` (used by tests that load it explicitly). |
+
+Tests that need a variable declare it with `require-env`; if a variable is
+unset the test is skipped rather than failed.
+
+Then run a subset (DuckDB's unittest binary intercepts patterns ending in
+`.test` as file paths, so use a wildcard pattern instead):
+
+```bash
+# Whole Snowflake suite
+./build/release/test/unittest "*snowflake_*"
+
+# Just the pushdown tests (uses the [pushdown] group tag)
+./build/release/test/unittest "[pushdown]"
+
+# One specific test
+./build/release/test/unittest "*snowflake_basic_connectivity*"
+```
+
+`make test-snowflake` runs the same set as a debug build and enforces that
+`SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_USERNAME`, `SNOWFLAKE_PASSWORD`, and
+`SNOWFLAKE_DATABASE` are set — be aware that the Makefile target's variable
+list predates the move to key-pair auth and is not yet aligned with the
+`require-env` declarations inside the individual tests.
+
+### CI
+
+GitHub Actions runs:
+
+- `.github/workflows/MainDistributionPipeline.yml` — DuckDB extension build,
+  code-quality (format + clang-tidy), packaging.
+- `.github/workflows/test-with-snowflake.yml` — live-Snowflake suite, gated
+  on the `SNOWFLAKE_ACCOUNT` secret being available. Skips with a warning if
+  the repository variable `SKIP_SNOWFLAKE_TESTS` is set to `true`.
+
+## Code style
+
+Run the DuckDB formatter on any source files you change before opening a
+pull request:
+
+```bash
+python3 duckdb/scripts/format.py <changed-files>
+```
+
+To format everything: `make format-fix`.
+
+`clang-tidy` runs in CI under the `code-quality-check` job.
+
+### Test-file format note
+
+DuckDB's SQLLogicTest parser is strict: `# group:` must come immediately
+after `# description:` in the header block, before any continuation comment
+lines. CI will fail otherwise.
+
+## Branch and PR conventions
+
+- Branch off `main`.
+- Branch names use a short `type/topic` form: `fix/issue-26-pem-parsing`,
+  `update/duckdb-v1.5.3`, `chore/repo-polish`. The `type/` prefix maps to
+  one of `fix`, `feat`, `update`, `chore`, `docs`.
+- Open a draft PR early if you want feedback; mark it ready when CI is
+  green.
+- Reference any issue the PR closes with `Closes #N` in the description.
+- Keep the PR scoped to one logical change. The `Post-1.5.3 cleanup` PR
+  (#40, four issues in one commit) is the exception, not the rule — that
+  bundling was deliberate because the fixes shared the same regression
+  surface.
+- Do not push to `main`. Do not force-push to a shared branch unless you
+  own it.
+
+### Crediting external contributors
+
+When a maintainer lands a contribution from a forked PR (e.g. via squash-and-
+merge), include a `Co-Authored-By:` trailer in the commit message giving
+credit to the original author using the email GitHub shows on their commits:
+
+```
+Co-Authored-By: Author Name <user@example.com>
+```
+
+PRs from external contributors that are merged unchanged don't need a manual
+trailer — GitHub's merge UI handles authorship. The trailer matters when a
+maintainer cherry-picks, rebases, or rewrites the commit during merge.
+
+Do not add `Co-Authored-By:` trailers for tools, AI assistants, or the
+maintainer themself.
+
+## Reporting bugs and requesting features
+
+Use the issue templates under
+[`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/). Bug reports must
+include the DuckDB version, the extension version (`SELECT
+snowflake_version();`), the Snowflake authentication method, and a minimal
+SQL repro.
+
+## Security
+
+Don't file security issues in the public tracker. See
+[SECURITY.md](SECURITY.md) for the disclosure process.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # DuckDB Snowflake Extension
 
-A powerful DuckDB extension that enables seamless querying of Snowflake databases using Arrow ADBC drivers. This extension provides efficient, columnar data transfer between DuckDB and Snowflake, making it ideal for analytics, ETL pipelines, and cross-database operations.
+[![Main Extension Distribution Pipeline](https://github.com/iqea-ai/duckdb-snowflake/actions/workflows/MainDistributionPipeline.yml/badge.svg?branch=main)](https://github.com/iqea-ai/duckdb-snowflake/actions/workflows/MainDistributionPipeline.yml)
+[![Test with Snowflake](https://github.com/iqea-ai/duckdb-snowflake/actions/workflows/test-with-snowflake.yml/badge.svg?branch=main)](https://github.com/iqea-ai/duckdb-snowflake/actions/workflows/test-with-snowflake.yml)
+[![Community Extension](https://img.shields.io/badge/community--extensions-snowflake-blue)](https://github.com/duckdb/community-extensions/blob/main/extensions/snowflake/description.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+A DuckDB extension for querying Snowflake from DuckDB via the Apache Arrow ADBC Snowflake driver. Data flows between the two systems as Arrow record batches, so result sets stay columnar end-to-end.
 
 **This extension works with DuckDB v1.5.3.**
 
@@ -68,15 +73,15 @@ If you want to **install and use** the extension, continue reading this README f
 
 ## Overview
 
-The DuckDB Snowflake Extension bridges the gap between DuckDB's analytical capabilities and Snowflake's cloud data warehouse, allowing you to query Snowflake data directly from DuckDB without complex data movement processes.
+The extension exposes Snowflake to DuckDB as a remote data source. You can either pass SQL straight through to Snowflake with `snowflake_query()`, or `ATTACH` a Snowflake database and query it with DuckDB SQL.
 
-### Key Features
+### Capabilities
 
-- **Direct Querying**: Execute SQL queries against Snowflake from within DuckDB
-- **Arrow-Native Pipeline**: Leverages Apache Arrow for efficient, columnar data transfer
-- **Multiple Authentication Methods**: Support for password, OAuth, key-pair (with passphrase support), external browser SSO, Okta, and MFA authentication
-- **Secret Management**: Secure credential storage using DuckDB's secrets system
-- **Storage Extension**: Attach Snowflake databases as read-only storage
+- Run SQL against Snowflake from DuckDB, either as passthrough (`snowflake_query`) or against an attached Snowflake database
+- Arrow-native transport over the ADBC Snowflake driver
+- Authentication via password, OAuth, key pair (with passphrase), external browser SSO, Okta, and MFA
+- Credentials stored through DuckDB's secrets system
+- Read-only storage extension for `ATTACH`
 
 ## Installation
 
@@ -206,7 +211,7 @@ Test that the driver is found:
 ```sql
 LOAD snowflake;
 SELECT snowflake_version();
--- Should return: "Snowflake Extension v0.1.0"
+-- Should return: "Snowflake Extension v0.4.1"
 ```
 
 ## Configuration
@@ -299,7 +304,7 @@ Returns the extension version information.
 
 ```sql
 SELECT snowflake_version();
--- Returns: "Snowflake Extension v0.1.0"
+-- Returns: "Snowflake Extension v0.4.1"
 ```
 
 ### Table Functions
@@ -346,7 +351,7 @@ SELECT * FROM snow.public.customers LIMIT 10;
 ### Complex Analytics
 
 ```sql
--- Use Snowflake's computational power for complex analytics
+-- Run the analytics on the Snowflake side, then return the result set
 SELECT * FROM snowflake_query(
     '
     WITH monthly_sales AS (

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security Policy
+
+## Supported Versions
+
+Only the most recent extension release line is supported with security fixes.
+The DuckDB column shows the DuckDB version each extension line is built and
+tested against.
+
+| Extension version | DuckDB version | Status |
+| --- | --- | --- |
+| 0.4.x | v1.5.3 | Supported |
+| 0.3.x and earlier | v1.5.0 — v1.5.2 | End of life |
+
+When a new minor release ships, the previous line is dropped from support.
+The community-extensions registry only serves the latest published version,
+so upgrading means re-running `INSTALL snowflake FROM community;` from a
+matching DuckDB version.
+
+## Reporting a Vulnerability
+
+Email **security@iqea.ai** with:
+
+- A description of the issue and the impact you observed.
+- The extension version (`SELECT snowflake_version();`), the DuckDB version,
+  the platform, and the authentication method in use.
+- A minimal reproduction — SQL statements, commands, or a small repo.
+- Whether the issue is already public and whether you've coordinated
+  disclosure with anyone else.
+
+Please **don't** file the report in the public GitHub issue tracker, and
+don't open a draft PR with the fix until we've agreed on a disclosure
+timeline.
+
+### What to expect
+
+- **Acknowledgement** within 3 business days.
+- **Initial assessment** (whether we can reproduce, severity rating, rough
+  remediation plan) within 10 business days.
+- A coordinated disclosure window proportional to severity — typically
+  30–90 days from acknowledgement, longer if a downstream dependency
+  (DuckDB core, the ADBC Snowflake driver, Snowflake itself) needs to ship
+  first.
+- Credit in the release notes and the advisory, unless you'd prefer to
+  remain anonymous.
+
+We treat reports about the upstream
+[`adbc-drivers/snowflake`](https://github.com/adbc-drivers/snowflake) driver
+or DuckDB core itself as out of scope for this repo, but we will help
+forward them to the right maintainer if you want.
+
+## Scope
+
+In scope:
+
+- Code in this repository (the extension, the build scripts, the GitHub
+  Actions workflows).
+- The packaging pipeline that produces the community-extensions binary.
+
+Out of scope:
+
+- Vulnerabilities in DuckDB itself — please report to
+  https://github.com/duckdb/duckdb/security.
+- Vulnerabilities in the ADBC Snowflake driver — please report to
+  https://github.com/adbc-drivers/snowflake.
+- Snowflake account misconfigurations (over-permissive roles, leaked keys,
+  etc.) — those are a Snowflake operational concern.

--- a/scripts/labels.sh
+++ b/scripts/labels.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Create the issue/PR label taxonomy for iqea-ai/duckdb-snowflake.
+#
+# Run this once against the repo (you need the `gh` CLI authenticated with
+# write access). It is idempotent: `gh label create --force` will create the
+# label if it doesn't exist and update color/description if it does.
+#
+# Usage:
+#   ./scripts/labels.sh                       # uses the current repo from git remote
+#   GH_REPO=iqea-ai/duckdb-snowflake ./scripts/labels.sh
+#
+
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found on PATH" >&2
+  exit 1
+fi
+
+REPO_FLAG=()
+if [[ -n "${GH_REPO:-}" ]]; then
+  REPO_FLAG=(--repo "$GH_REPO")
+fi
+
+create() {
+  local name="$1"
+  local color="$2"
+  local description="$3"
+  gh label create "$name" \
+    --color "$color" \
+    --description "$description" \
+    --force \
+    "${REPO_FLAG[@]}"
+}
+
+# Type
+create "bug"              "d73a4a" "Something is broken or behaves unexpectedly"
+create "enhancement"      "a2eeef" "New feature or capability request"
+create "documentation"    "0075ca" "Docs, examples, READMEs, comments"
+
+# Triage / lifecycle
+create "needs-repro"      "fbca04" "Cannot reproduce yet — waiting on more info from reporter"
+create "upstream-blocked" "5319e7" "Fix or feature depends on DuckDB core, ADBC driver, or Snowflake"
+create "wontfix"          "ffffff" "Closed without action — out of scope or by design"
+
+# Onboarding
+create "good first issue" "7057ff" "Scoped, well-understood, friendly to a first-time contributor"
+
+echo "Done."

--- a/src/snowflake_extension.cpp
+++ b/src/snowflake_extension.cpp
@@ -25,7 +25,7 @@ void RegisterSnowflakeSecretType(DatabaseInstance &instance);
 
 inline void SnowflakeVersionScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
 	result.SetVectorType(VectorType::CONSTANT_VECTOR);
-	auto val = Value("Snowflake Extension v0.1.0");
+	auto val = Value("Snowflake Extension v0.4.1");
 	result.SetValue(0, val);
 }
 


### PR DESCRIPTION
## Summary

Documentation and repo-hygiene polish on top of `main` at the v1.5.3 line. No source changes except the one-line bump of `snowflake_version()`'s return string from `v0.1.0` to `v0.4.1`.

## What's in this PR

- **Version reconciliation** — `snowflake_version()` returned the scaffold-era string `Snowflake Extension v0.1.0`. Bumped to `v0.4.1` to match the in-flight community-extensions descriptor. Synced the two README references and one BUILD.md reference to the same value. (DuckDB version strings — `v1.5.3` in workflows, install paths, AUTHENTICATION.md — were left untouched.)
- **CHANGELOG.md** — backfilled in Keep a Changelog 1.1.0 format from git log + `gh pr view`. Covers 0.4.1 (DuckDB v1.5.3 via #39, Setzer's #34/#35, the #33/#36/#37/#38 cleanup bundle via #40, workflow hardening via #41) and 0.4.0 (DuckDB v1.5.2 via #31, ADBC option-key fixes via #30, PEM/segfault fixes via #27).
- **CONTRIBUTING.md** — build/test commands pulled from the Makefile and CI, the actual `SNOWFLAKE_*` env vars declared by `require-env` in each test file, branch/PR conventions, external-contributor Co-Authored-By guidance.
- **SECURITY.md** — `security@iqea.ai` contact, supported-versions table (0.4.x only), response-time expectations, out-of-scope items routed to DuckDB core / ADBC driver.
- **.github/ templates** — `PULL_REQUEST_TEMPLATE.md` + `ISSUE_TEMPLATE/{bug_report,feature_request,question}.md` + `config.yml` (blank issues disabled, security routed to SECURITY.md, upstream issues routed to DuckDB/ADBC trackers). Bug template asks for extension version, DuckDB version, install method, ADBC driver, Snowflake auth method, repro.
- **scripts/labels.sh** — idempotent `gh label create --force` for `bug`, `enhancement`, `wontfix`, `documentation`, `good first issue`, `upstream-blocked`, `needs-repro`. **Not applied automatically — run it yourself when you're ready.**
- **README polish** — badge row (Main Distribution Pipeline, Test with Snowflake, community-extensions, MIT license); minimal, surgical tonedown of marketing copy in the lead paragraph, Overview, and Complex Analytics example; the two `snowflake_version()` expected-output lines updated to `v0.4.1`.

## Files touched

| File | Change |
| --- | --- |
| `src/snowflake_extension.cpp` | `v0.1.0` → `v0.4.1` |
| `README.md` | badges + tonedown + 2× version sync |
| `BUILD.md` | 1× version sync |
| `CHANGELOG.md` | new |
| `CONTRIBUTING.md` | new |
| `SECURITY.md` | new |
| `.github/PULL_REQUEST_TEMPLATE.md` | new |
| `.github/ISSUE_TEMPLATE/bug_report.md` | new |
| `.github/ISSUE_TEMPLATE/feature_request.md` | new |
| `.github/ISSUE_TEMPLATE/question.md` | new |
| `.github/ISSUE_TEMPLATE/config.yml` | new |
| `scripts/labels.sh` | new |

## Open TODOs (not invented — flagged where I couldn't determine a real value)

1. **CHANGELOG "Earlier" section** — pre-0.4.0 release-to-version mapping isn't in this repo. Pulled from `duckdb/community-extensions` history would close it out. Marked `TODO` inline.
2. **`test/README.md` and `make test-snowflake`** — both still list the password-auth env var set (`SNOWFLAKE_PASSWORD`), but most `test/sql/*.test` files have moved to key-pair auth (`SNOWFLAKE_PRIVATE_KEY_FILE`, `SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE`, `SNOWFLAKE_KEYPAIR_USER`, `SNOWFLAKE_PRIVATE_KEY_PATH`, `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE`). Not touched here because the plan said `chore` only — but worth a follow-up.
3. **CI workflow `secrets.SNOWFLAKE_PASSWORD`** — `.github/workflows/test-with-snowflake.yml` still exports a `SNOWFLAKE_PASSWORD`-shaped credential set. Same story as #2 — not in scope for this PR.

## What I deliberately did **not** touch

- PR #42, PR #24, any open issues.
- The DuckDB submodule pin.
- The CI workflows (other than badging them in README).
- The community-extensions descriptor (separate repo, separate PR per memory).

## Verification

- `python3 duckdb/scripts/format.py src/snowflake_extension.cpp` → Passed format-check.
- All new files are markdown / shell — no compile step.
- Did not run the live-Snowflake suite (no source-side behavior change).

## Reviewer ask

This is opened as **Draft**. Don't mark ready / merge — sanity-check the version choice (`0.4.1` vs anything you'd prefer) and the CHANGELOG mapping, then I'll flip it ready once you approve.