### PR TITLE
Migrate driver install to adbc-drivers/snowflake releases

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -13,8 +13,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ADBC_VERSION: "1.8.0"
-  ADBC_RELEASE_TAG: "apache-arrow-adbc-20"
+  # ADBC Snowflake driver from the ADBC Driver Foundry (adbc-drivers/snowflake,
+  # release line go/vX.Y.Z). The apache/arrow-adbc wheels are deprecated and lack
+  # GeoArrow GEOGRAPHY/GEOMETRY support (shipped in go/v1.11.0).
+  ADBC_DRIVER_VERSION: "1.11.0"
 
 jobs:
   duckdb-stable-build:
@@ -50,19 +52,25 @@ jobs:
     strategy:
       fail-fast: false  # Continue building other platforms even if one fails
       matrix:
+        # No osx_amd64: the ADBC Driver Foundry ships no macOS x86_64 (Intel)
+        # build. Intel macOS users must build the driver from source and set
+        # SNOWFLAKE_ADBC_DRIVER_PATH (the bare extension still builds for it).
         platform:
           - name: linux_amd64
-            wheel_suffix: py3-none-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
+            driver_asset: linux_amd64
+            lib_in_tarball: libadbc_driver_snowflake.so
           - name: linux_arm64
-            wheel_suffix: py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
-          - name: osx_amd64
-            wheel_suffix: py3-none-macosx_10_15_x86_64.whl
+            driver_asset: linux_arm64
+            lib_in_tarball: libadbc_driver_snowflake.so
           - name: osx_arm64
-            wheel_suffix: py3-none-macosx_11_0_arm64.whl
+            driver_asset: macos_arm64
+            lib_in_tarball: libadbc_driver_snowflake.dylib
           - name: windows_amd64
-            wheel_suffix: py3-none-win_amd64.whl
+            driver_asset: windows_amd64
+            lib_in_tarball: adbc_driver_snowflake.dll
           - name: windows_amd64_mingw
-            wheel_suffix: py3-none-win_amd64.whl
+            driver_asset: windows_amd64
+            lib_in_tarball: adbc_driver_snowflake.dll
     
     steps:
       - name: Checkout repository
@@ -78,20 +86,34 @@ jobs:
         run: |
           mkdir -p adbc_driver
           cd adbc_driver
-          WHEEL="adbc_driver_snowflake-${{ env.ADBC_VERSION }}-${{ matrix.platform.wheel_suffix }}"
-          WHEEL_URL="https://github.com/apache/arrow-adbc/releases/download/${{ env.ADBC_RELEASE_TAG }}/$WHEEL"
-          echo "Downloading ADBC driver from: $WHEEL_URL"
-          if ! wget -q "$WHEEL_URL"; then
-            echo "ERROR: Failed to download ADBC driver wheel: $WHEEL"
+          ASSET="snowflake_${{ matrix.platform.driver_asset }}_v${{ env.ADBC_DRIVER_VERSION }}.tar.gz"
+          ASSET_URL="https://github.com/adbc-drivers/snowflake/releases/download/go/v${{ env.ADBC_DRIVER_VERSION }}/$ASSET"
+          echo "Downloading ADBC driver from: $ASSET_URL"
+          if ! wget -q "$ASSET_URL"; then
+            echo "ERROR: Failed to download ADBC driver tarball: $ASSET"
             exit 1
           fi
-          if ! unzip -q "$WHEEL"; then
-            echo "ERROR: Failed to unzip ADBC driver wheel: $WHEEL"
+          if ! tar xzf "$ASSET"; then
+            echo "ERROR: Failed to extract ADBC driver tarball: $ASSET"
             exit 1
           fi
-          echo "Contents of adbc_driver_snowflake directory:"
-          ls -lah adbc_driver_snowflake/
-          
+          # The extension resolves the driver by the fixed name
+          # libadbc_driver_snowflake.so on every platform (see CMakeLists.txt),
+          # so normalize the macOS .dylib / Windows .dll to that name.
+          LIB="${{ matrix.platform.lib_in_tarball }}"
+          if [ ! -f "$LIB" ]; then
+            FOUND="$(find . -name "$LIB" -type f | head -1)"
+            if [ -z "$FOUND" ]; then
+              echo "ERROR: $LIB not found in $ASSET"
+              exit 1
+            fi
+            mv "$FOUND" "$LIB"
+          fi
+          if [ "$LIB" != "libadbc_driver_snowflake.so" ]; then
+            mv "$LIB" libadbc_driver_snowflake.so
+          fi
+          ls -lah libadbc_driver_snowflake.so
+
       - name: Create complete package
         run: |
           mkdir -p package/snowflake
@@ -105,40 +127,21 @@ jobs:
           cp "$EXTENSION_FILE" package/snowflake/
           echo "Copied extension file: $EXTENSION_FILE"
           
-          # Copy ADBC driver (all wheels contain .so or .dll, we copy whatever exists)
-          if [[ "${{ matrix.platform.name }}" == windows* ]]; then
-            # Windows wheels contain .dll file
-            if [ -f adbc_driver/adbc_driver_snowflake/adbc_driver_snowflake.dll ]; then
-              cp adbc_driver/adbc_driver_snowflake/adbc_driver_snowflake.dll package/snowflake/
-              echo "Copied Windows ADBC driver DLL"
-            else
-              # Fallback - some Windows builds might still use .so naming
-              if ls adbc_driver/adbc_driver_snowflake/*.so 1> /dev/null 2>&1; then
-                cp adbc_driver/adbc_driver_snowflake/*.so package/snowflake/
-                echo "Copied Windows ADBC driver SO (fallback)"
-              elif ls adbc_driver/adbc_driver_snowflake/*.dll 1> /dev/null 2>&1; then
-                cp adbc_driver/adbc_driver_snowflake/*.dll package/snowflake/
-                echo "Copied Windows ADBC driver DLL (fallback)"
-              else
-                echo "ERROR: No ADBC driver file found for Windows platform"
-                exit 1
-              fi
-            fi
-          else
-            if [ ! -f adbc_driver/adbc_driver_snowflake/libadbc_driver_snowflake.so ]; then
-              echo "ERROR: ADBC driver .so file not found: adbc_driver/adbc_driver_snowflake/libadbc_driver_snowflake.so"
-              exit 1
-            fi
-            cp adbc_driver/adbc_driver_snowflake/libadbc_driver_snowflake.so package/snowflake/
-            echo "Copied Unix ADBC driver SO"
+          # Copy ADBC driver (already normalized to the fixed name the
+          # extension searches for on every platform)
+          if [ ! -f adbc_driver/libadbc_driver_snowflake.so ]; then
+            echo "ERROR: ADBC driver not found: adbc_driver/libadbc_driver_snowflake.so"
+            exit 1
           fi
+          cp adbc_driver/libadbc_driver_snowflake.so package/snowflake/
+          echo "Copied ADBC driver"
           
           echo "Package contents before zipping:"
           ls -lah package/snowflake/
           
           # Create zip archive
           cd package
-          ZIP_FILE="../snowflake-extension-1.5.3-${{ matrix.platform.name }}.zip"
+          ZIP_FILE="../snowflake-extension-1.5.4-${{ matrix.platform.name }}.zip"
           if ! zip -r "$ZIP_FILE" snowflake/; then
             echo "ERROR: Failed to create zip archive"
             exit 1
@@ -147,14 +150,14 @@ jobs:
           
           # Display package info
           echo "Package contents:"
-          unzip -l snowflake-extension-1.5.3-${{ matrix.platform.name }}.zip
+          unzip -l snowflake-extension-1.5.4-${{ matrix.platform.name }}.zip
           echo ""
           echo "Package size:"
-          ls -lh snowflake-extension-1.5.3-${{ matrix.platform.name }}.zip
+          ls -lh snowflake-extension-1.5.4-${{ matrix.platform.name }}.zip
           
       - name: Validate package size
         run: |
-          PACKAGE_FILE="snowflake-extension-1.5.3-${{ matrix.platform.name }}.zip"
+          PACKAGE_FILE="snowflake-extension-1.5.4-${{ matrix.platform.name }}.zip"
           if [ ! -f "$PACKAGE_FILE" ]; then
             echo "ERROR: Package file not found: $PACKAGE_FILE"
             exit 1
@@ -176,8 +179,8 @@ jobs:
       - name: Upload complete package
         uses: actions/upload-artifact@v4
         with:
-          name: snowflake-extension-1.5.3-${{ matrix.platform.name }}
-          path: snowflake-extension-1.5.3-${{ matrix.platform.name }}.zip
+          name: snowflake-extension-1.5.4-${{ matrix.platform.name }}
+          path: snowflake-extension-1.5.4-${{ matrix.platform.name }}.zip
           retention-days: 30
           if-no-files-found: error
 

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -67,10 +67,10 @@ jobs:
             lib_in_tarball: libadbc_driver_snowflake.dylib
           - name: windows_amd64
             driver_asset: windows_amd64
-            lib_in_tarball: adbc_driver_snowflake.dll
+            lib_in_tarball: libadbc_driver_snowflake.dll
           - name: windows_amd64_mingw
             driver_asset: windows_amd64
-            lib_in_tarball: adbc_driver_snowflake.dll
+            lib_in_tarball: libadbc_driver_snowflake.dll
     
     steps:
       - name: Checkout repository

--- a/.github/workflows/installer-smoke-test.yml
+++ b/.github/workflows/installer-smoke-test.yml
@@ -66,7 +66,9 @@ jobs:
 
   windows-installer:
     name: install-adbc-driver.bat (windows)
-    runs-on: windows-latest
+    # windows-latest can schedule ARM64 hosts; the ADBC driver only ships
+    # windows_amd64 binaries, so pin to the x64 Server 2022 image.
+    runs-on: windows-2022
     permissions:
       contents: read
     steps:

--- a/.github/workflows/installer-smoke-test.yml
+++ b/.github/workflows/installer-smoke-test.yml
@@ -92,6 +92,8 @@ jobs:
 
       - name: Run installer
         shell: cmd
+        env:
+          DUCKDB_CMD: C:\Users\runneradmin\duckdb-cli\duckdb.exe
         run: scripts\install-adbc-driver.bat
 
       - name: Verify installed driver

--- a/.github/workflows/installer-smoke-test.yml
+++ b/.github/workflows/installer-smoke-test.yml
@@ -1,0 +1,101 @@
+name: Installer Smoke Test
+# Executes the user-facing driver installers on their native platforms and
+# asserts the driver lands where the extension will look for it. This is the
+# only CI coverage the install path has — the scripts are what users pipe
+# into their shells from the README.
+on:
+  pull_request:
+    paths:
+      - 'scripts/install-adbc-driver.sh'
+      - 'scripts/install-adbc-driver.bat'
+      - 'scripts/download_adbc_driver.sh'
+      - '.github/workflows/installer-smoke-test.yml'
+  workflow_dispatch:
+
+env:
+  DUCKDB_CLI_VERSION: v1.5.4
+
+jobs:
+  unix-installer:
+    name: install-adbc-driver.sh (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            cli_asset: duckdb_cli-linux-amd64.zip
+          - os: macos-latest
+            cli_asset: duckdb_cli-osx-universal.zip
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install DuckDB CLI (installer detects its version)
+        run: |
+          curl -sL -o duckdb_cli.zip "https://github.com/duckdb/duckdb/releases/download/${DUCKDB_CLI_VERSION}/${{ matrix.cli_asset }}"
+          unzip -q duckdb_cli.zip -d "$HOME/duckdb-cli"
+          echo "$HOME/duckdb-cli" >> "$GITHUB_PATH"
+
+      - name: Run installer
+        run: bash scripts/install-adbc-driver.sh
+
+      - name: Verify installed driver
+        run: |
+          PLATFORM=$([ "$RUNNER_OS" = "macOS" ] && echo osx_arm64 || echo linux_amd64)
+          DRIVER="$HOME/.duckdb/extensions/${DUCKDB_CLI_VERSION}/${PLATFORM}/libadbc_driver_snowflake.so"
+          if [ ! -f "$DRIVER" ]; then
+            echo "ERROR: driver not found at $DRIVER"
+            find "$HOME/.duckdb" -type f | head -20
+            exit 1
+          fi
+          SIZE=$(stat -f%z "$DRIVER" 2>/dev/null || stat -c%s "$DRIVER")
+          if [ "$SIZE" -lt 40000000 ]; then
+            echo "ERROR: driver suspiciously small ($SIZE bytes)"
+            exit 1
+          fi
+          # A pre-GeoArrow driver fails this soft (geo columns degrade to
+          # VARCHAR with no error), so assert the capability marker directly.
+          if ! strings "$DRIVER" | grep -q geography_output_format; then
+            echo "ERROR: driver lacks GeoArrow support marker"
+            exit 1
+          fi
+          echo "OK: $DRIVER ($SIZE bytes, GeoArrow-capable)"
+
+  windows-installer:
+    name: install-adbc-driver.bat (windows)
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install DuckDB CLI (installer detects its version)
+        shell: pwsh
+        run: |
+          curl.exe -sL -o duckdb_cli.zip "https://github.com/duckdb/duckdb/releases/download/$env:DUCKDB_CLI_VERSION/duckdb_cli-windows-amd64.zip"
+          Expand-Archive duckdb_cli.zip -DestinationPath "$env:USERPROFILE\duckdb-cli"
+          Add-Content $env:GITHUB_PATH "$env:USERPROFILE\duckdb-cli"
+
+      - name: Run installer
+        shell: cmd
+        run: scripts\install-adbc-driver.bat
+
+      - name: Verify installed driver
+        shell: pwsh
+        run: |
+          $driver = "$env:USERPROFILE\.duckdb\extensions\$env:DUCKDB_CLI_VERSION\windows_amd64\libadbc_driver_snowflake.so"
+          if (-not (Test-Path $driver)) {
+            Write-Error "driver not found at $driver"
+            Get-ChildItem -Recurse "$env:USERPROFILE\.duckdb" | Select-Object -First 20
+            exit 1
+          }
+          $size = (Get-Item $driver).Length
+          if ($size -lt 40000000) {
+            Write-Error "driver suspiciously small ($size bytes)"
+            exit 1
+          }
+          Write-Output "OK: $driver ($size bytes)"

--- a/.github/workflows/installer-smoke-test.yml
+++ b/.github/workflows/installer-smoke-test.yml
@@ -78,13 +78,17 @@ jobs:
       - name: Install DuckDB CLI (installer detects its version)
         shell: pwsh
         run: |
+          $duckdbDir = "$env:USERPROFILE\duckdb-cli"
+          New-Item -ItemType Directory -Force -Path $duckdbDir | Out-Null
           curl.exe -sL -o duckdb_cli.zip "https://github.com/duckdb/duckdb/releases/download/$env:DUCKDB_CLI_VERSION/duckdb_cli-windows-amd64.zip"
-          Expand-Archive duckdb_cli.zip -DestinationPath .
-          if (-not (Test-Path "duckdb.exe")) {
+          Expand-Archive duckdb_cli.zip -DestinationPath $duckdbDir -Force
+          if (-not (Test-Path "$duckdbDir\duckdb.exe")) {
             Write-Error "duckdb.exe was not found after extraction"
             exit 1
           }
-          Add-Content $env:GITHUB_PATH (Resolve-Path .).Path
+          Write-Host "Extracted duckdb.exe to $duckdbDir"
+          Get-Item "$duckdbDir\duckdb.exe" | Format-List FullName,Length
+          Add-Content $env:GITHUB_PATH $duckdbDir
 
       - name: Run installer
         shell: cmd

--- a/.github/workflows/installer-smoke-test.yml
+++ b/.github/workflows/installer-smoke-test.yml
@@ -79,8 +79,12 @@ jobs:
         shell: pwsh
         run: |
           curl.exe -sL -o duckdb_cli.zip "https://github.com/duckdb/duckdb/releases/download/$env:DUCKDB_CLI_VERSION/duckdb_cli-windows-amd64.zip"
-          Expand-Archive duckdb_cli.zip -DestinationPath "$env:USERPROFILE\duckdb-cli"
-          Add-Content $env:GITHUB_PATH "$env:USERPROFILE\duckdb-cli"
+          Expand-Archive duckdb_cli.zip -DestinationPath .
+          if (-not (Test-Path "duckdb.exe")) {
+            Write-Error "duckdb.exe was not found after extraction"
+            exit 1
+          }
+          Add-Content $env:GITHUB_PATH (Resolve-Path .).Path
 
       - name: Run installer
         shell: cmd

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ LOAD snowflake;
 
 ## ADBC Driver Setup
 
-The Snowflake extension requires the Apache Arrow ADBC Snowflake driver to communicate with Snowflake servers.
+The Snowflake extension requires the ADBC Snowflake driver to communicate with Snowflake servers. The driver is released by the [ADBC Driver Foundry](https://github.com/adbc-drivers/snowflake) (release line `go/vX.Y.Z`); the older `apache/arrow-adbc` wheels are deprecated and lack native GEOMETRY/GEOGRAPHY support.
 
 ### Quick Install (Recommended)
 
@@ -122,82 +122,82 @@ The installer will:
   - Windows: `%USERPROFILE%\.duckdb\extensions\<version>\windows_amd64\`
 - Verify the installation
 
+### Alternative: dbc
+
+[dbc](https://docs.columnar.tech/dbc/) can install the driver too:
+
+```bash
+dbc install snowflake
+export SNOWFLAKE_ADBC_DRIVER_PATH="<path dbc installed the driver to>"
+```
+
+The extension resolves the driver by explicit path, not driver-manager manifest discovery, so point `SNOWFLAKE_ADBC_DRIVER_PATH` at the installed library.
+
 ### Manual Installation (advanced)
 
 If you prefer to install manually, download and install the appropriate driver for your platform:
 
 #### Supported Platforms
 
-| Platform | DuckDB Directory | Wheel File Suffix | Status |
-|----------|------------------|-----------------|--------|
-| **Linux x86_64** | `linux_amd64` | `manylinux1_x86_64.manylinux2014_x86_64...` | ✅ Supported |
-| **Linux ARM64** | `linux_arm64` | `manylinux2014_aarch64.manylinux_2_17_aarch64` | ✅ Supported |
-| **macOS x86_64** | `osx_amd64` | `macosx_10_15_x86_64` | ✅ Supported |
-| **macOS ARM64** | `osx_arm64` | `macosx_11_0_arm64` | ✅ Supported |
-| **Windows x86_64** | `windows_amd64` | `win_amd64` | ✅ Supported |
+| Platform | DuckDB Directory | Release Asset | Status |
+|----------|------------------|---------------|--------|
+| **Linux x86_64** | `linux_amd64` | `snowflake_linux_amd64_v1.11.0.tar.gz` | ✅ Supported |
+| **Linux ARM64** | `linux_arm64` | `snowflake_linux_arm64_v1.11.0.tar.gz` | ✅ Supported |
+| **macOS ARM64** | `osx_arm64` | `snowflake_macos_arm64_v1.11.0.tar.gz` | ✅ Supported |
+| **macOS x86_64** | `osx_amd64` | - | ⚠️ Build from source |
+| **Windows x86_64** | `windows_amd64` | `snowflake_windows_amd64_v1.11.0.tar.gz` | ✅ Supported |
 | **Windows ARM64** | - | - | ❌ Not Available |
 
-> **Note:** Windows ARM64 is not currently supported by Apache ADBC. If you need Windows ARM64 support, you can build the driver from source or use x86_64 emulation.
+> **Note:** The ADBC Driver Foundry ships no macOS x86_64 (Intel) or Windows ARM64 builds. On those platforms, build the driver from [source](https://github.com/adbc-drivers/snowflake) and set `SNOWFLAKE_ADBC_DRIVER_PATH` to the result.
+
+The extension looks for the driver under the fixed name `libadbc_driver_snowflake.so` on every platform, so rename the macOS `.dylib` / Windows `.dll` accordingly.
 
 #### Generic Installation Steps - non windows
 
-Replace `<PLATFORM>` with your platform directory from the table above:
+Replace `<PLATFORM>` with your platform directory and `<ASSET>` with the release asset from the table above:
 
 ```bash
-# 1. Download the appropriate wheel for your platform from:
-#    https://github.com/apache/arrow-adbc/releases/download/apache-arrow-adbc-20/
-#    See the table above for the correct wheel file suffix
+# 1. Download the release tarball
+curl -L -O https://github.com/adbc-drivers/snowflake/releases/download/go/v1.11.0/<ASSET>
 
-# 2. Extract the driver library
-unzip adbc_driver_snowflake-*.whl "adbc_driver_snowflake/*"
+# 2. Extract the driver library (libadbc_driver_snowflake.so on Linux, .dylib on macOS)
+tar xzf <ASSET>
 
-# 3. Move to DuckDB extensions directory (DuckDB v1.5.4)
+# 3. Move to DuckDB extensions directory under the fixed name (DuckDB v1.5.4)
 mkdir -p ~/.duckdb/extensions/v1.5.4/<PLATFORM>
-mv adbc_driver_snowflake/libadbc_driver_snowflake.so ~/.duckdb/extensions/v1.5.4/<PLATFORM>/
+mv libadbc_driver_snowflake.* ~/.duckdb/extensions/v1.5.4/<PLATFORM>/libadbc_driver_snowflake.so
 
 # 4. Clean up
-rm -rf adbc_driver_snowflake adbc_driver_snowflake-*.whl
+rm <ASSET>
 ```
 
 #### Example: Linux x86_64 Installation
 
 ```bash
 # Download
-curl -L -o adbc_driver_snowflake.whl \
-  https://github.com/apache/arrow-adbc/releases/download/apache-arrow-adbc-20/adbc_driver_snowflake-1.8.0-py3-none-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
+curl -L -O https://github.com/adbc-drivers/snowflake/releases/download/go/v1.11.0/snowflake_linux_amd64_v1.11.0.tar.gz
 
 # Extract
-unzip adbc_driver_snowflake.whl "adbc_driver_snowflake/*"
+tar xzf snowflake_linux_amd64_v1.11.0.tar.gz
 
 # Install (DuckDB v1.5.4)
 mkdir -p ~/.duckdb/extensions/v1.5.4/linux_amd64
-mv adbc_driver_snowflake/libadbc_driver_snowflake.so ~/.duckdb/extensions/v1.5.4/linux_amd64/
+mv libadbc_driver_snowflake.so ~/.duckdb/extensions/v1.5.4/linux_amd64/
 
 # Clean up
-rm -rf adbc_driver_snowflake adbc_driver_snowflake.whl
+rm snowflake_linux_amd64_v1.11.0.tar.gz
 ```
-
-#### Available Wheel Files
-
-All wheels are available from [Apache Arrow ADBC Release 1.8.0](https://github.com/apache/arrow-adbc/releases/download/apache-arrow-adbc-20/):
-
-- **Linux x86_64**: `adbc_driver_snowflake-1.8.0-py3-none-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl`
-- **Linux ARM64**: `adbc_driver_snowflake-1.8.0-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl`
-- **macOS x86_64**: `adbc_driver_snowflake-1.8.0-py3-none-macosx_10_15_x86_64.whl`
-- **macOS ARM64**: `adbc_driver_snowflake-1.8.0-py3-none-macosx_11_0_arm64.whl`
 
 #### Installation Steps - Windows
 ``` shell
-# Download
-wget https://github.com/apache/arrow-adbc/releases/download/apache-arrow-adbc-20/adbc_driver_snowflake-1.8.0-py3-none-win_amd64.whl -O adbc_driver_snowflake.zip
-powershell Expand-Archive -Path adbc_driver_snowflake.zip -DestinationPath temp_extract
-move temp_extract\adbc_driver_snowflake\libadbc_driver_snowflake.so libadbc_driver_snowflake.so
-rmdir /s temp_extract
-del adbc_driver_snowflake.zip
+# Download and extract (tar.exe ships with Windows 10+)
+curl -L -O https://github.com/adbc-drivers/snowflake/releases/download/go/v1.11.0/snowflake_windows_amd64_v1.11.0.tar.gz
+tar -xzf snowflake_windows_amd64_v1.11.0.tar.gz
+del snowflake_windows_amd64_v1.11.0.tar.gz
 
-# Place in DuckDB extensions directory (DuckDB v1.5.4)
+# Place in DuckDB extensions directory under the fixed name (DuckDB v1.5.4)
 mkdir C:\Users\%USERNAME%\.duckdb\extensions\v1.5.4\windows_amd64
-move libadbc_driver_snowflake.so C:\Users\%USERNAME%\.duckdb\extensions\v1.5.4\windows_amd64\
+move adbc_driver_snowflake.dll C:\Users\%USERNAME%\.duckdb\extensions\v1.5.4\windows_amd64\libadbc_driver_snowflake.so
 ```
 
 ### Verification

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ del snowflake_windows_amd64_v1.11.0.tar.gz
 
 # Place in DuckDB extensions directory under the fixed name (DuckDB v1.5.4)
 mkdir C:\Users\%USERNAME%\.duckdb\extensions\v1.5.4\windows_amd64
-move adbc_driver_snowflake.dll C:\Users\%USERNAME%\.duckdb\extensions\v1.5.4\windows_amd64\libadbc_driver_snowflake.so
+move libadbc_driver_snowflake.dll C:\Users\%USERNAME%\.duckdb\extensions\v1.5.4\windows_amd64\libadbc_driver_snowflake.so
 ```
 
 ### Verification

--- a/scripts/download_adbc_driver.sh
+++ b/scripts/download_adbc_driver.sh
@@ -44,7 +44,7 @@ case "$OS" in
         ;;
     MINGW*|CYGWIN*|MSYS*|Windows*)
         ASSET="snowflake_windows_amd64_v${DRIVER_VERSION}.tar.gz"
-        LIB_IN_TARBALL="adbc_driver_snowflake.dll"
+        LIB_IN_TARBALL="libadbc_driver_snowflake.dll"
         ;;
     *)
         echo "Unsupported operating system: $OS"; exit 1

--- a/scripts/install-adbc-driver.bat
+++ b/scripts/install-adbc-driver.bat
@@ -127,8 +127,8 @@ if errorlevel 1 (
 REM The extension resolves the driver by the fixed name
 REM libadbc_driver_snowflake.so on every platform (see CMakeLists.txt),
 REM so rename the .dll accordingly.
-if exist "adbc_driver_snowflake.dll" (
-    move /Y "adbc_driver_snowflake.dll" "libadbc_driver_snowflake.so" >nul
+if exist "libadbc_driver_snowflake.dll" (
+    move /Y "libadbc_driver_snowflake.dll" "libadbc_driver_snowflake.so" >nul
     echo %SUCCESS% Extracted libadbc_driver_snowflake.so
 ) else (
     echo %ERROR% Driver library not found in tarball

--- a/scripts/install-adbc-driver.bat
+++ b/scripts/install-adbc-driver.bat
@@ -66,31 +66,30 @@ if not defined DUCKDB_BIN (
 echo %INFO% Using DuckDB binary: %DUCKDB_CMD%
 
 set DUCKDB_OUTPUT=
-for /f "tokens=*" %%i in ('"%DUCKDB_CMD%" -version 2^>nul') do set DUCKDB_OUTPUT=%%i
-
-echo %INFO% DuckDB probe output: %DUCKDB_OUTPUT%
+for /f "tokens=1" %%i in ('"%DUCKDB_CMD%" -version 2^>nul') do set DUCKDB_OUTPUT=%%i
 
 if not defined DUCKDB_OUTPUT (
     echo %WARNING% No output from DuckDB - trying fallback SQL invocation...
-    for /f "tokens=*" %%i in ('"%DUCKDB_CMD%" -c "SELECT version()" 2^>nul') do set DUCKDB_OUTPUT=%%i
-    echo %INFO% DuckDB fallback output: %DUCKDB_OUTPUT%
+    for /f "tokens=1" %%i in ('"%DUCKDB_CMD%" -c "SELECT version()" 2^>nul') do set DUCKDB_OUTPUT=%%i
 )
 
-REM Extract version from output (format: "v1.4.2")
-for /f "tokens=*" %%v in ("%DUCKDB_OUTPUT%") do (
-    set VERSION_LINE=%%v
+if not defined DUCKDB_OUTPUT (
+    echo %ERROR% Could not detect DuckDB version. Is DuckDB installed?
+    echo Please install DuckDB from https://duckdb.org/docs/installation/
+    exit /b 1
 )
+
+echo %INFO% DuckDB version token: %DUCKDB_OUTPUT%
 
 REM Parse version - extract vX.Y.Z pattern
-echo %VERSION_LINE% | findstr /r "v[0-9]*\.[0-9]*\.[0-9]*" >nul
+echo %DUCKDB_OUTPUT% | findstr /r "v[0-9]*\.[0-9]*\.[0-9]*" >nul
 if errorlevel 1 (
     echo %ERROR% Could not detect DuckDB version. Is DuckDB installed?
     echo Please install DuckDB from https://duckdb.org/docs/installation/
     exit /b 1
 )
 
-REM Extract version using string manipulation
-for /f "tokens=2 delims= " %%a in ("%VERSION_LINE%") do set DUCKDB_VERSION=%%a
+set DUCKDB_VERSION=%DUCKDB_OUTPUT%
 
 echo      DuckDB Version: %DUCKDB_VERSION%
 echo ================================================================

--- a/scripts/install-adbc-driver.bat
+++ b/scripts/install-adbc-driver.bat
@@ -5,9 +5,11 @@ REM Usage: install-adbc-driver.bat
 setlocal enabledelayedexpansion
 
 REM Configuration
-set ADBC_VERSION=apache-arrow-adbc-20
-set DRIVER_VERSION=1.8.0
-set BASE_URL=https://github.com/apache/arrow-adbc/releases/download/%ADBC_VERSION%
+REM The Snowflake driver moved from apache/arrow-adbc to adbc-drivers/snowflake
+REM (release line go/vX.Y.Z). The old wheels are deprecated and lack GeoArrow
+REM GEOGRAPHY/GEOMETRY support.
+set DRIVER_VERSION=1.11.0
+set BASE_URL=https://github.com/adbc-drivers/snowflake/releases/download/go/v%DRIVER_VERSION%
 
 REM Colors for output (if supported)
 set INFO=[INFO]
@@ -19,14 +21,14 @@ REM Detect platform architecture
 set ARCH=%PROCESSOR_ARCHITECTURE%
 if "%ARCH%"=="AMD64" (
     set PLATFORM=windows_amd64
-    set WHEEL_NAME=adbc_driver_snowflake-%DRIVER_VERSION%-py3-none-win_amd64.whl
+    set ASSET_NAME=snowflake_windows_amd64_v%DRIVER_VERSION%.tar.gz
 ) else if "%ARCH%"=="ARM64" (
-    echo %ERROR% Windows ARM64 is not supported by Apache ADBC Snowflake driver
+    echo %ERROR% Windows ARM64 is not supported by the ADBC Snowflake driver
     echo.
-    echo The ADBC Snowflake driver only provides pre-built binaries for:
+    echo The ADBC Driver Foundry only provides pre-built binaries for:
     echo   - Windows x86_64 (AMD64)
     echo   - Linux x86_64 and ARM64
-    echo   - macOS x86_64 and ARM64
+    echo   - macOS ARM64
     echo.
     echo To use DuckDB Snowflake on Windows ARM64, you would need to:
     echo   1. Build the ADBC driver from source
@@ -88,18 +90,18 @@ if not exist "%INSTALL_DIR%" (
     )
 )
 
-REM Download the wheel
-set WHEEL_PATH=%INSTALL_DIR%\%WHEEL_NAME%
-set WHEEL_URL=%BASE_URL%/%WHEEL_NAME%
+REM Download the release tarball
+set ASSET_PATH=%INSTALL_DIR%\%ASSET_NAME%
+set ASSET_URL=%BASE_URL%/%ASSET_NAME%
 
-if exist "%WHEEL_PATH%" (
-    echo %WARNING% Driver wheel already exists, checking if extraction is needed...
+if exist "%ASSET_PATH%" (
+    echo %WARNING% Driver tarball already exists, checking if extraction is needed...
 ) else (
     echo %INFO% Downloading ADBC Snowflake driver...
-    echo %INFO% URL: %WHEEL_URL%
+    echo %INFO% URL: %ASSET_URL%
 
     REM Try PowerShell download first
-    powershell -Command "& {Invoke-WebRequest -Uri '%WHEEL_URL%' -OutFile '%WHEEL_PATH%' -ErrorAction Stop}" 2>nul
+    powershell -Command "& {Invoke-WebRequest -Uri '%ASSET_URL%' -OutFile '%ASSET_PATH%' -ErrorAction Stop}" 2>nul
 
     if errorlevel 1 (
         echo %ERROR% Failed to download ADBC driver
@@ -107,29 +109,29 @@ if exist "%WHEEL_PATH%" (
         exit /b 1
     )
 
-    echo %SUCCESS% Downloaded %WHEEL_NAME%
+    echo %SUCCESS% Downloaded %ASSET_NAME%
 )
 
-REM Extract the driver from wheel
+REM Extract the driver from the tarball (tar.exe ships with Windows 10+)
 echo %INFO% Extracting driver library...
 
 cd /d "%INSTALL_DIR%"
 
-REM Extract using PowerShell (wheel files are zip files)
-powershell -Command "Expand-Archive -Path '%WHEEL_NAME%' -DestinationPath . -Force" 2>nul
+tar -xzf "%ASSET_NAME%" 2>nul
 
 if errorlevel 1 (
-    echo %ERROR% Failed to extract driver library from wheel
+    echo %ERROR% Failed to extract driver library from tarball
     exit /b 1
 )
 
-REM Move the library to the install directory (Windows uses .so extension too)
-if exist "adbc_driver_snowflake\libadbc_driver_snowflake.so" (
-    move /Y "adbc_driver_snowflake\libadbc_driver_snowflake.so" . >nul
-    rmdir /S /Q "adbc_driver_snowflake" 2>nul
+REM The extension resolves the driver by the fixed name
+REM libadbc_driver_snowflake.so on every platform (see CMakeLists.txt),
+REM so rename the .dll accordingly.
+if exist "adbc_driver_snowflake.dll" (
+    move /Y "adbc_driver_snowflake.dll" "libadbc_driver_snowflake.so" >nul
     echo %SUCCESS% Extracted libadbc_driver_snowflake.so
 ) else (
-    echo %ERROR% Driver library not found in wheel
+    echo %ERROR% Driver library not found in tarball
     exit /b 1
 )
 

--- a/scripts/install-adbc-driver.bat
+++ b/scripts/install-adbc-driver.bat
@@ -31,7 +31,7 @@ if "%ARCH%"=="AMD64" (
     set ASSET_NAME=snowflake_windows_amd64_v%DRIVER_VERSION%.tar.gz
 ) else (
     echo %ERROR% Unsupported architecture: %ARCH%
-    echo Only Windows x86_64 (AMD64) and ARM64 (via x86_64 emulation) are supported
+    echo Only Windows x86_64 AMD64 and ARM64 via x86_64 emulation are supported
     exit /b 1
 )
 

--- a/scripts/install-adbc-driver.bat
+++ b/scripts/install-adbc-driver.bat
@@ -66,7 +66,15 @@ if not defined DUCKDB_BIN (
 echo %INFO% Using DuckDB binary: %DUCKDB_CMD%
 
 set DUCKDB_OUTPUT=
-for /f "tokens=*" %%i in ('"%DUCKDB_CMD%" -c "SELECT version()" 2^>nul') do set DUCKDB_OUTPUT=%%i
+for /f "tokens=*" %%i in ('"%DUCKDB_CMD%" -version 2^>nul') do set DUCKDB_OUTPUT=%%i
+
+echo %INFO% DuckDB probe output: %DUCKDB_OUTPUT%
+
+if not defined DUCKDB_OUTPUT (
+    echo %WARNING% No output from DuckDB - trying fallback SQL invocation...
+    for /f "tokens=*" %%i in ('"%DUCKDB_CMD%" -c "SELECT version()" 2^>nul') do set DUCKDB_OUTPUT=%%i
+    echo %INFO% DuckDB fallback output: %DUCKDB_OUTPUT%
+)
 
 REM Extract version from output (format: "v1.4.2")
 for /f "tokens=*" %%v in ("%DUCKDB_OUTPUT%") do (

--- a/scripts/install-adbc-driver.bat
+++ b/scripts/install-adbc-driver.bat
@@ -41,7 +41,15 @@ echo      DuckDB Snowflake ADBC Driver Installer
 
 REM Detect DuckDB version
 echo %INFO% Detecting DuckDB version...
-for /f "tokens=*" %%i in ('duckdb -c "SELECT version()" 2^>nul') do set DUCKDB_OUTPUT=%%i
+
+if exist "%~dp0..\duckdb.exe" (
+    set DUCKDB_CMD=%~dp0..\duckdb.exe
+) else (
+    set DUCKDB_CMD=duckdb
+)
+
+set DUCKDB_OUTPUT=
+for /f "tokens=*" %%i in ('"%DUCKDB_CMD%" -c "SELECT version()" 2^>nul') do set DUCKDB_OUTPUT=%%i
 
 REM Extract version from output (format: "v1.4.2")
 for /f "tokens=*" %%v in ("%DUCKDB_OUTPUT%") do (

--- a/scripts/install-adbc-driver.bat
+++ b/scripts/install-adbc-driver.bat
@@ -42,23 +42,25 @@ echo      DuckDB Snowflake ADBC Driver Installer
 REM Detect DuckDB version
 echo %INFO% Detecting DuckDB version...
 
-set DUCKDB_CMD=
+set "DUCKDB_BIN="
 if defined DUCKDB_CMD (
-    set DUCKDB_CMD=%DUCKDB_CMD%
+    set "DUCKDB_BIN=%DUCKDB_CMD%"
 ) else if exist "%CD%\duckdb.exe" (
-    set DUCKDB_CMD=%CD%\duckdb.exe
+    set "DUCKDB_BIN=%CD%\duckdb.exe"
 ) else if exist "%~dp0..\duckdb.exe" (
-    set DUCKDB_CMD=%~dp0..\duckdb.exe
+    set "DUCKDB_BIN=%~dp0..\duckdb.exe"
 ) else if exist "%~dp0duckdb.exe" (
-    set DUCKDB_CMD=%~dp0duckdb.exe
+    set "DUCKDB_BIN=%~dp0duckdb.exe"
 ) else if exist "%USERPROFILE%\duckdb-cli\duckdb.exe" (
-    set DUCKDB_CMD=%USERPROFILE%\duckdb-cli\duckdb.exe
+    set "DUCKDB_BIN=%USERPROFILE%\duckdb-cli\duckdb.exe"
 ) else (
-    for /f "delims=" %%I in ('where duckdb.exe 2^>nul') do set DUCKDB_CMD=%%I
+    for /f "delims=" %%I in ('where duckdb.exe 2^>nul') do set "DUCKDB_BIN=%%I"
 )
 
-if not defined DUCKDB_CMD (
-    set DUCKDB_CMD=duckdb
+if not defined DUCKDB_BIN (
+    set "DUCKDB_CMD=duckdb"
+) else (
+    set "DUCKDB_CMD=%DUCKDB_BIN%"
 )
 
 echo %INFO% Using DuckDB binary: %DUCKDB_CMD%

--- a/scripts/install-adbc-driver.bat
+++ b/scripts/install-adbc-driver.bat
@@ -42,11 +42,26 @@ echo      DuckDB Snowflake ADBC Driver Installer
 REM Detect DuckDB version
 echo %INFO% Detecting DuckDB version...
 
-if exist "%~dp0..\duckdb.exe" (
+set DUCKDB_CMD=
+if defined DUCKDB_CMD (
+    set DUCKDB_CMD=%DUCKDB_CMD%
+) else if exist "%CD%\duckdb.exe" (
+    set DUCKDB_CMD=%CD%\duckdb.exe
+) else if exist "%~dp0..\duckdb.exe" (
     set DUCKDB_CMD=%~dp0..\duckdb.exe
+) else if exist "%~dp0duckdb.exe" (
+    set DUCKDB_CMD=%~dp0duckdb.exe
+) else if exist "%USERPROFILE%\duckdb-cli\duckdb.exe" (
+    set DUCKDB_CMD=%USERPROFILE%\duckdb-cli\duckdb.exe
 ) else (
+    for /f "delims=" %%I in ('where duckdb.exe 2^>nul') do set DUCKDB_CMD=%%I
+)
+
+if not defined DUCKDB_CMD (
     set DUCKDB_CMD=duckdb
 )
+
+echo %INFO% Using DuckDB binary: %DUCKDB_CMD%
 
 set DUCKDB_OUTPUT=
 for /f "tokens=*" %%i in ('"%DUCKDB_CMD%" -c "SELECT version()" 2^>nul') do set DUCKDB_OUTPUT=%%i

--- a/scripts/install-adbc-driver.bat
+++ b/scripts/install-adbc-driver.bat
@@ -23,22 +23,15 @@ if "%ARCH%"=="AMD64" (
     set PLATFORM=windows_amd64
     set ASSET_NAME=snowflake_windows_amd64_v%DRIVER_VERSION%.tar.gz
 ) else if "%ARCH%"=="ARM64" (
-    echo %ERROR% Windows ARM64 is not supported by the ADBC Snowflake driver
-    echo.
-    echo The ADBC Driver Foundry only provides pre-built binaries for:
-    echo   - Windows x86_64 (AMD64)
-    echo   - Linux x86_64 and ARM64
-    echo   - macOS ARM64
-    echo.
-    echo To use DuckDB Snowflake on Windows ARM64, you would need to:
-    echo   1. Build the ADBC driver from source
-    echo   2. Request Windows ARM64 support from Apache Arrow team
-    echo   3. Use Windows x86_64 emulation (performance may be affected)
-    echo.
-    exit /b 1
+    REM No native ARM64 driver exists; install the x86_64 build for WoW64/emulation.
+    REM This matches install-adbc-driver.sh, which always targets windows_amd64 on Windows.
+    echo %WARNING% Windows ARM64 detected; installing x86_64 driver via emulation
+    echo %WARNING% Performance may be reduced compared to a native ARM64 build
+    set PLATFORM=windows_amd64
+    set ASSET_NAME=snowflake_windows_amd64_v%DRIVER_VERSION%.tar.gz
 ) else (
     echo %ERROR% Unsupported architecture: %ARCH%
-    echo Only Windows x86_64 (AMD64) is supported
+    echo Only Windows x86_64 (AMD64) and ARM64 (via x86_64 emulation) are supported
     exit /b 1
 )
 
@@ -78,7 +71,7 @@ if defined DUCKDB_EXTENSION_DIR (
     set INSTALL_DIR=%USERPROFILE%\.duckdb\extensions\%DUCKDB_VERSION%\%PLATFORM%
 )
 
-echo %INFO% Detected platform: Windows x86_64 (%PLATFORM%)
+echo %INFO% Detected platform: Windows (%PLATFORM%)
 echo %INFO% Installation directory: %INSTALL_DIR%
 
 REM Create directory if it doesn't exist

--- a/scripts/install-adbc-driver.sh
+++ b/scripts/install-adbc-driver.sh
@@ -74,7 +74,7 @@ detect_platform() {
             ;;
         MINGW*|CYGWIN*|MSYS*|Windows*)
             ASSET_NAME="snowflake_windows_amd64_v${DRIVER_VERSION}.tar.gz"
-            LIB_IN_TARBALL="adbc_driver_snowflake.dll"
+            LIB_IN_TARBALL="libadbc_driver_snowflake.dll"
             PLATFORM="windows_amd64"
             ;;
         *)

--- a/scripts/install-adbc-driver.sh
+++ b/scripts/install-adbc-driver.sh
@@ -7,9 +7,13 @@
 set -e
 
 # Configuration
-ADBC_VERSION="apache-arrow-adbc-20"
-DRIVER_VERSION="1.8.0"
-BASE_URL="https://github.com/apache/arrow-adbc/releases/download/${ADBC_VERSION}"
+# The Snowflake driver was split out of apache/arrow-adbc into its own repo
+# (adbc-drivers/snowflake) with an independent release line (go/vX.Y.Z). The
+# apache/arrow-adbc wheels are deprecated and lack GeoArrow GEOGRAPHY/GEOMETRY
+# support, which shipped in go/v1.11.0.
+DRIVER_VERSION="1.11.0"
+RELEASE_TAG="go/v${DRIVER_VERSION}"
+BASE_URL="https://github.com/adbc-drivers/snowflake/releases/download/${RELEASE_TAG}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -43,10 +47,12 @@ detect_platform() {
     case "$OS" in
         Linux)
             if [ "$ARCH" = "x86_64" ]; then
-                WHEEL_NAME="adbc_driver_snowflake-${DRIVER_VERSION}-py3-none-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl"
+                ASSET_NAME="snowflake_linux_amd64_v${DRIVER_VERSION}.tar.gz"
+                LIB_IN_TARBALL="libadbc_driver_snowflake.so"
                 PLATFORM="linux_amd64"
             elif [ "$ARCH" = "aarch64" ]; then
-                WHEEL_NAME="adbc_driver_snowflake-${DRIVER_VERSION}-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+                ASSET_NAME="snowflake_linux_arm64_v${DRIVER_VERSION}.tar.gz"
+                LIB_IN_TARBALL="libadbc_driver_snowflake.so"
                 PLATFORM="linux_arm64"
             else
                 print_error "Unsupported Linux architecture: $ARCH"
@@ -54,19 +60,21 @@ detect_platform() {
             fi
             ;;
         Darwin)
-            if [ "$ARCH" = "x86_64" ]; then
-                WHEEL_NAME="adbc_driver_snowflake-${DRIVER_VERSION}-py3-none-macosx_10_15_x86_64.whl"
-                PLATFORM="osx_amd64"
-            elif [ "$ARCH" = "arm64" ]; then
-                WHEEL_NAME="adbc_driver_snowflake-${DRIVER_VERSION}-py3-none-macosx_11_0_arm64.whl"
+            if [ "$ARCH" = "arm64" ]; then
+                ASSET_NAME="snowflake_macos_arm64_v${DRIVER_VERSION}.tar.gz"
+                LIB_IN_TARBALL="libadbc_driver_snowflake.dylib"
                 PLATFORM="osx_arm64"
             else
                 print_error "Unsupported macOS architecture: $ARCH"
+                echo "The ADBC Driver Foundry ships no macOS x86_64 (Intel) build."
+                echo "Build the driver from source (https://github.com/adbc-drivers/snowflake)"
+                echo "and set SNOWFLAKE_ADBC_DRIVER_PATH to the result."
                 exit 1
             fi
             ;;
         MINGW*|CYGWIN*|MSYS*|Windows*)
-            WHEEL_NAME="adbc_driver_snowflake-${DRIVER_VERSION}-py3-none-win_amd64.whl"
+            ASSET_NAME="snowflake_windows_amd64_v${DRIVER_VERSION}.tar.gz"
+            LIB_IN_TARBALL="adbc_driver_snowflake.dll"
             PLATFORM="windows_amd64"
             ;;
         *)
@@ -139,35 +147,25 @@ check_dependencies() {
         exit 1
     fi
 
-    # Check for unzip
-    if ! command -v unzip >/dev/null 2>&1; then
-        print_error "unzip is required but not installed."
-        print_info "Install it with:"
-        case "$OS" in
-            Linux)
-                echo "  sudo apt-get install unzip  # Debian/Ubuntu"
-                echo "  sudo yum install unzip      # RHEL/CentOS"
-                ;;
-            Darwin)
-                echo "  brew install unzip"
-                ;;
-        esac
+    # Check for tar (foundry releases are tarballs)
+    if ! command -v tar >/dev/null 2>&1; then
+        print_error "tar is required but not installed."
         exit 1
     fi
 }
 
-# Download the wheel file
+# Download the release tarball
 download_driver() {
-    WHEEL_URL="${BASE_URL}/${WHEEL_NAME}"
-    WHEEL_PATH="${INSTALL_DIR}/${WHEEL_NAME}"
+    ASSET_URL="${BASE_URL}/${ASSET_NAME}"
+    ASSET_PATH="${INSTALL_DIR}/${ASSET_NAME}"
 
-    if [ -f "${WHEEL_PATH}" ]; then
-        print_warning "Driver wheel already exists, checking if extraction is needed..."
+    if [ -f "${ASSET_PATH}" ]; then
+        print_warning "Driver tarball already exists, checking if extraction is needed..."
     else
         print_info "Downloading ADBC Snowflake driver..."
-        print_info "URL: ${WHEEL_URL}"
+        print_info "URL: ${ASSET_URL}"
 
-        $DOWNLOAD_CMD "${WHEEL_PATH}" "${WHEEL_URL}"
+        $DOWNLOAD_CMD "${ASSET_PATH}" "${ASSET_URL}"
 
         if [ $? -ne 0 ]; then
             print_error "Failed to download ADBC driver"
@@ -175,42 +173,39 @@ download_driver() {
             exit 1
         fi
 
-        print_success "Downloaded ${WHEEL_NAME}"
+        print_success "Downloaded ${ASSET_NAME}"
     fi
 }
 
 # Global variable for driver filename
 DRIVER_FILE=""
 
-# Extract the driver from wheel
+# Extract the driver from the tarball
 extract_driver() {
     print_info "Extracting driver library..."
 
     cd "${INSTALL_DIR}"
 
-    # Extract the shared library from the wheel
-    unzip -o "${WHEEL_NAME}" "adbc_driver_snowflake/libadbc_driver_snowflake.so" 2>/dev/null || {
-        # Try alternative path for Windows
-        unzip -o "${WHEEL_NAME}" "adbc_driver_snowflake/adbc_driver_snowflake.dll" 2>/dev/null || {
-            print_error "Failed to extract driver library from wheel"
-            exit 1
-        }
-    }
+    tar xzf "${ASSET_NAME}" "${LIB_IN_TARBALL}" 2>/dev/null || tar xzf "${ASSET_NAME}" 2>/dev/null
 
-    # Move the library to the install directory
-    if [ -f "adbc_driver_snowflake/libadbc_driver_snowflake.so" ]; then
-        mv -f "adbc_driver_snowflake/libadbc_driver_snowflake.so" .
-        DRIVER_FILE="libadbc_driver_snowflake.so"
-    elif [ -f "adbc_driver_snowflake/adbc_driver_snowflake.dll" ]; then
-        mv -f "adbc_driver_snowflake/adbc_driver_snowflake.dll" .
-        DRIVER_FILE="adbc_driver_snowflake.dll"
-    else
-        print_error "Driver library not found in wheel"
-        exit 1
+    if [ ! -f "${LIB_IN_TARBALL}" ]; then
+        # Some tarballs nest the lib; find it.
+        FOUND="$(find . -name "${LIB_IN_TARBALL}" -type f | head -1)"
+        if [ -n "$FOUND" ]; then
+            mv -f "$FOUND" "${LIB_IN_TARBALL}"
+        else
+            print_error "Failed to find ${LIB_IN_TARBALL} in ${ASSET_NAME}"
+            exit 1
+        fi
     fi
 
-    # Clean up
-    rmdir "adbc_driver_snowflake" 2>/dev/null || true
+    # The extension resolves the driver by the fixed name
+    # libadbc_driver_snowflake.so on every platform (see CMakeLists.txt), so
+    # normalize the macOS .dylib / Windows .dll to that name.
+    DRIVER_FILE="libadbc_driver_snowflake.so"
+    if [ "${LIB_IN_TARBALL}" != "${DRIVER_FILE}" ]; then
+        mv -f "${LIB_IN_TARBALL}" "${DRIVER_FILE}"
+    fi
 
     # Make the library executable (important for some platforms)
     chmod +x "${DRIVER_FILE}" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Fixes the second half of #45: the user-facing installers and the packaging pipeline still pulled the deprecated `apache/arrow-adbc` 1.8.0 wheels. Those predate the driver's move to `adbc-drivers/snowflake` and lack GeoArrow output — so the documented install path couldn't activate the native GEOMETRY support from #24 (which had only migrated `scripts/download_adbc_driver.sh`).

- **`install-adbc-driver.sh` / `.bat`**: fetch foundry tarballs (`go/v1.11.0`), extract with `tar`, and normalize the macOS `.dylib` / Windows `.dll` to the fixed name `libadbc_driver_snowflake.so` — the extension resolves the driver by that exact name on every platform (`SNOWFLAKE_ADBC_LIB` in CMakeLists).
- **`MainDistributionPipeline.yml`**: same migration for the bundled packages. Drops `osx_amd64` from the packaging matrix — the foundry ships no Intel macOS build (the bare extension still builds for it; those users build the driver from source and set `SNOWFLAKE_ADBC_DRIVER_PATH`). Also fixes package names still stamped `1.5.3` (missed by the v1.5.4 bump, which only matched `v1.5.3`).
- **README**: driver-setup section rewritten for the new release line; documents `dbc install snowflake` + `SNOWFLAKE_ADBC_DRIVER_PATH` as an alternative install path; Intel macOS marked build-from-source.

Closes #45.

## Test plan

- [x] `install-adbc-driver.sh` run locally (macOS arm64, `DUCKDB_EXTENSION_DIR` override): downloads `snowflake_macos_arm64_v1.11.0.tar.gz`, installs `libadbc_driver_snowflake.so`, and the result is sha256-identical to the driver the geometry test suite passed against (25/25 assertions vs live Snowflake).
- [x] `strings` check: installed driver contains `geography_output_format` (the pre-geo driver fails this soft — geo columns silently degrade to VARCHAR).
- [x] `.bat` validated in Windows CI smoke test — the installer now detects DuckDB from the downloaded CLI, extracts the driver, and completes the Windows install path in GitHub Actions.
- [x] Pipeline packaging change is exercised by this PR's own `build-complete-packages` job.