### PR TITLE
Use a connection pool so concurrent scans don't share one Snowflake connection

### DIFF
--- a/src/include/snowflake_arrow_utils.hpp
+++ b/src/include/snowflake_arrow_utils.hpp
@@ -16,8 +16,9 @@ namespace duckdb {
 // function which expects a factory that can produce ArrowArrayStreamWrapper
 // instances
 struct SnowflakeArrowStreamFactory {
-	// Snowflake connection managed by the client manager
-	shared_ptr<snowflake::SnowflakeClient> connection;
+	// Connection leased exclusively for this scan, so no other scan drives it
+	// concurrently (ADBC connections are not thread-safe). Returned on destruction.
+	snowflake::ConnectionLease lease;
 
 	// SQL query to execute (original base query)
 	std::string query;
@@ -48,19 +49,20 @@ struct SnowflakeArrowStreamFactory {
 	TableFilterSet *current_filters = nullptr;
 	vector<string> column_names; // Maps column indices to names for filter building
 
-	SnowflakeArrowStreamFactory(shared_ptr<snowflake::SnowflakeClient> conn, const std::string &query_str)
-	    : connection(std::move(conn)), query(query_str), modified_query(query_str) {
+	SnowflakeArrowStreamFactory(snowflake::ConnectionLease lease_p, const std::string &query_str)
+	    : lease(std::move(lease_p)), query(query_str), modified_query(query_str) {
 		std::memset(&statement, 0, sizeof(statement));
 		std::memset(&cached_stream, 0, sizeof(cached_stream));
 	}
 
 	~SnowflakeArrowStreamFactory() {
-		// Clean up the ADBC statement if it was initialized
+		// Release ADBC resources that live on the leased connection BEFORE the
+		// lease (declared first, destroyed last) returns that connection to the
+		// pool — the statement/stream are backed by this connection.
 		if (statement_initialized) {
 			AdbcError error;
 			AdbcStatementRelease(&statement, &error);
 		}
-		// Release cached stream if present
 		if (has_cached_stream && cached_stream.release) {
 			cached_stream.release(&cached_stream);
 		}

--- a/src/include/snowflake_client_manager.hpp
+++ b/src/include/snowflake_client_manager.hpp
@@ -6,28 +6,109 @@
 #include <memory>
 #include <unordered_map>
 #include <mutex>
+#include <vector>
 
 namespace duckdb {
 namespace snowflake {
 
+class SnowflakeClientManager;
+
+//! RAII lease for a pooled SnowflakeClient. While the lease is alive it has
+//! exclusive use of one ADBC connection; on destruction the connection is
+//! returned to the manager's idle pool for reuse (unless invalidated). ADBC
+//! connections are not thread-safe, so at most one live lease may drive a given
+//! connection at a time — which is precisely what the pool guarantees.
+class ConnectionLease {
+public:
+	ConnectionLease() = default;
+	ConnectionLease(SnowflakeClientManager &manager, SnowflakeConfig config, shared_ptr<SnowflakeClient> client)
+	    : manager(&manager), config(std::move(config)), client(std::move(client)) {
+	}
+	~ConnectionLease();
+
+	ConnectionLease(ConnectionLease &&other) noexcept
+	    : manager(other.manager), config(std::move(other.config)), client(std::move(other.client)),
+	      reusable(other.reusable) {
+		other.manager = nullptr;
+		other.client = nullptr;
+	}
+	ConnectionLease &operator=(ConnectionLease &&other) noexcept {
+		if (this != &other) {
+			Reset();
+			manager = other.manager;
+			config = std::move(other.config);
+			client = std::move(other.client);
+			reusable = other.reusable;
+			other.manager = nullptr;
+			other.client = nullptr;
+		}
+		return *this;
+	}
+	ConnectionLease(const ConnectionLease &) = delete;
+	ConnectionLease &operator=(const ConnectionLease &) = delete;
+
+	SnowflakeClient *operator->() const {
+		return client.get();
+	}
+	SnowflakeClient &operator*() const {
+		return *client;
+	}
+	SnowflakeClient *get() const {
+		return client.get();
+	}
+	explicit operator bool() const {
+		return client != nullptr;
+	}
+
+	//! Mark this connection as not reusable (e.g. after an auth/session error);
+	//! it is dropped instead of returned to the idle pool when the lease ends.
+	void Invalidate() {
+		reusable = false;
+	}
+
+private:
+	void Reset();
+
+	SnowflakeClientManager *manager = nullptr;
+	SnowflakeConfig config;
+	shared_ptr<SnowflakeClient> client;
+	bool reusable = true;
+};
+
+//! Process-wide pool of Snowflake ADBC connections, keyed by credentials.
+//! Acquire() hands out a dedicated connection per concurrent scan / metadata
+//! call; the connection is returned to a per-config idle list for reuse when its
+//! lease is destroyed. There is intentionally NO cap on concurrently-active
+//! leases: a single DuckDB query can legitimately hold several Arrow scan
+//! streams open at once (e.g. UNION ALL with preserve_insertion_order=false), so
+//! capping active connections would deadlock. Only the number of retained *idle*
+//! connections is bounded.
 class SnowflakeClientManager {
 public:
 	static SnowflakeClientManager &GetInstance();
 
-	shared_ptr<SnowflakeClient> GetConnection(const SnowflakeConfig &config);
+	//! Acquire an exclusive connection for the given config, reusing a validated
+	//! idle connection if available, otherwise creating and connecting a new one.
+	//! The returned lease returns the connection to the pool on destruction.
+	ConnectionLease Acquire(const SnowflakeConfig &config);
 
-	void ReleaseConnection(const SnowflakeConfig &config);
-
-	//! Invalidate a connection (e.g., on auth error) and force reconnection on next GetConnection
-	void InvalidateConnection(const SnowflakeConfig &config);
-
-	//! Get a fresh connection, bypassing the cache (for retry after auth failure)
-	shared_ptr<SnowflakeClient> GetFreshConnection(const SnowflakeConfig &config);
+	//! Close and forget all idle connections for a config (e.g. on DETACH, or
+	//! after an auth error). Active leases keep their own connection alive until
+	//! released, at which point they are dropped rather than pooled if stale.
+	void DrainIdle(const SnowflakeConfig &config);
 
 private:
+	friend class ConnectionLease;
 	SnowflakeClientManager() = default;
-	std::unordered_map<SnowflakeConfig, shared_ptr<SnowflakeClient>, SnowflakeConfigHash> connections;
-	std::mutex connection_mutex;
+
+	//! Return a connection to the idle pool (called by ~ConnectionLease).
+	void Return(const SnowflakeConfig &config, shared_ptr<SnowflakeClient> client, bool reusable);
+
+	//! Cap on retained idle connections per config. Active leases are unbounded.
+	static constexpr size_t MAX_IDLE_PER_CONFIG = 8;
+
+	std::unordered_map<SnowflakeConfig, std::vector<shared_ptr<SnowflakeClient>>, SnowflakeConfigHash> idle_connections;
+	std::mutex pool_mutex;
 };
 
 } // namespace snowflake

--- a/src/include/storage/snowflake_catalog.hpp
+++ b/src/include/storage/snowflake_catalog.hpp
@@ -60,7 +60,7 @@ public:
 	                             PhysicalOperator &plan) override;
 
 private:
-	shared_ptr<SnowflakeClient> client;
+	SnowflakeConfig config;
 	SnowflakeSchemaSet schemas;
 	SnowflakeOptions options;
 };

--- a/src/include/storage/snowflake_schema_entry.hpp
+++ b/src/include/storage/snowflake_schema_entry.hpp
@@ -15,7 +15,7 @@ class SnowflakeTableSet;
 class SnowflakeSchemaEntry : public SchemaCatalogEntry {
 public:
 	SnowflakeSchemaEntry(Catalog &catalog, const string &schema_name, CreateSchemaInfo &info,
-	                     const shared_ptr<SnowflakeClient> &client);
+	                     const SnowflakeConfig &config);
 
 	optional_ptr<CatalogEntry> LookupEntry(CatalogTransaction transaction, const EntryLookupInfo &lookup_info) override;
 
@@ -54,7 +54,7 @@ public:
 	bool CatalogTypeIsSupported(CatalogType type);
 
 private:
-	shared_ptr<SnowflakeClient> client;
+	SnowflakeConfig config;
 	unique_ptr<SnowflakeTableSet> tables;
 };
 } // namespace snowflake

--- a/src/include/storage/snowflake_schema_set.hpp
+++ b/src/include/storage/snowflake_schema_set.hpp
@@ -8,8 +8,8 @@ namespace duckdb {
 namespace snowflake {
 class SnowflakeSchemaSet : public SnowflakeCatalogSet {
 public:
-	SnowflakeSchemaSet(Catalog &catalog, shared_ptr<SnowflakeClient> client)
-	    : SnowflakeCatalogSet(catalog), client(std::move(client)) {
+	SnowflakeSchemaSet(Catalog &catalog, SnowflakeConfig config)
+	    : SnowflakeCatalogSet(catalog), config(std::move(config)) {
 	}
 
 	//! Fetches all schemas from Snowflake and creates SnowflakeSchemaEntry
@@ -17,7 +17,7 @@ public:
 	void LoadEntries(ClientContext &context) override;
 
 private:
-	shared_ptr<SnowflakeClient> client;
+	SnowflakeConfig config;
 };
 } // namespace snowflake
 } // namespace duckdb

--- a/src/include/storage/snowflake_table_entry.hpp
+++ b/src/include/storage/snowflake_table_entry.hpp
@@ -44,16 +44,15 @@ struct SnowflakeTableBindData : public FunctionData {
 //! SnowflakeTableEntry represents a single table in Snowflake
 class SnowflakeTableEntry : public TableCatalogEntry {
 public:
-	SnowflakeTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTableInfo &info,
-	                    shared_ptr<SnowflakeClient> client)
-	    : TableCatalogEntry(catalog, schema, info), client(std::move(client)) {};
+	SnowflakeTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTableInfo &info, SnowflakeConfig config)
+	    : TableCatalogEntry(catalog, schema, info), config(std::move(config)) {};
 
 	string GetFullyQualifiedName() const {
 		return catalog.GetName() + "." + schema.name + "." + name;
 	}
 
 	const SnowflakeConfig &GetConfig() const {
-		return client->GetConfig();
+		return config;
 	}
 
 	TableFunction GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) override;
@@ -63,7 +62,7 @@ public:
 	TableStorageInfo GetStorageInfo(ClientContext &context) override;
 
 private:
-	shared_ptr<SnowflakeClient> client;
+	SnowflakeConfig config;
 	//! Serializes access to the schema cache and the lazy columns load below.
 	//! DuckDB shares catalog table entries across connections; concurrent
 	//! GetScanFunction calls on the same entry would otherwise race on the

--- a/src/include/storage/snowflake_table_set.hpp
+++ b/src/include/storage/snowflake_table_set.hpp
@@ -10,8 +10,8 @@ namespace snowflake {
 //! SnowflakeTableSet represents a set of tables in Snowflake
 class SnowflakeTableSet : public SnowflakeCatalogSet {
 public:
-	SnowflakeTableSet(SnowflakeSchemaEntry &schema, shared_ptr<SnowflakeClient> client, const string &schema_name)
-	    : SnowflakeCatalogSet(schema.catalog), schema(schema), client(std::move(client)), schema_name(schema_name) {
+	SnowflakeTableSet(SnowflakeSchemaEntry &schema, SnowflakeConfig config, const string &schema_name)
+	    : SnowflakeCatalogSet(schema.catalog), schema(schema), config(std::move(config)), schema_name(schema_name) {
 	}
 
 protected:
@@ -20,7 +20,7 @@ protected:
 
 private:
 	SnowflakeSchemaEntry &schema;
-	shared_ptr<SnowflakeClient> client;
+	SnowflakeConfig config;
 	const string schema_name;
 };
 } // namespace snowflake

--- a/src/snowflake_arrow_utils.cpp
+++ b/src/snowflake_arrow_utils.cpp
@@ -105,7 +105,7 @@ unique_ptr<ArrowArrayStreamWrapper> SnowflakeProduceArrowScan(uintptr_t factory_
 		std::memset(&error, 0, sizeof(error));
 
 		// Create a new ADBC statement from the connection
-		AdbcStatusCode status = AdbcStatementNew(factory->connection->GetConnection(), &factory->statement, &error);
+		AdbcStatusCode status = AdbcStatementNew(factory->lease->GetConnection(), &factory->statement, &error);
 		DPRINT("Statement created at %p for factory %p\n", (void *)&factory->statement, (void *)factory);
 		if (status != ADBC_STATUS_OK) {
 			throw IOException("Failed to create statement");
@@ -158,7 +158,10 @@ unique_ptr<ArrowArrayStreamWrapper> SnowflakeProduceArrowScan(uintptr_t factory_
 		if (IsAuthenticationError(error_msg)) {
 			// Invalidate the cached connection so next attempt gets a fresh one
 			auto &client_manager = snowflake::SnowflakeClientManager::GetInstance();
-			client_manager.InvalidateConnection(factory->connection->GetConfig());
+			// Don't return this connection to the pool, and drop any idle ones —
+			// the auth token has likely expired for all sessions on this config.
+			factory->lease.Invalidate();
+			client_manager.DrainIdle(factory->lease->GetConfig());
 			DPRINT("Authentication error detected, connection invalidated for retry\n");
 
 			// Provide a helpful error message
@@ -188,7 +191,7 @@ void SnowflakeGetArrowSchema(ArrowArrayStream *factory_ptr, ArrowSchema &schema)
 		AdbcError error;
 		std::memset(&error, 0, sizeof(error));
 
-		AdbcStatusCode status = AdbcStatementNew(factory->connection->GetConnection(), &factory->statement, &error);
+		AdbcStatusCode status = AdbcStatementNew(factory->lease->GetConnection(), &factory->statement, &error);
 		DPRINT("Statement created at %p for factory %p\n", (void *)&factory->statement, (void *)factory);
 		if (status != ADBC_STATUS_OK) {
 			throw IOException("Failed to create statement");
@@ -246,7 +249,7 @@ void SnowflakeGetArrowSchemaViaQuery(SnowflakeArrowStreamFactory *factory, Arrow
 	// which the scan production path creates and uses on its own.
 	AdbcStatement probe_stmt;
 	std::memset(&probe_stmt, 0, sizeof(probe_stmt));
-	AdbcStatusCode status = AdbcStatementNew(factory->connection->GetConnection(), &probe_stmt, &error);
+	AdbcStatusCode status = AdbcStatementNew(factory->lease->GetConnection(), &probe_stmt, &error);
 	if (status != ADBC_STATUS_OK) {
 		throw IOException("Failed to create statement for schema probe");
 	}
@@ -281,7 +284,10 @@ void SnowflakeGetArrowSchemaViaQuery(SnowflakeArrowStreamFactory *factory, Arrow
 		AdbcStatementRelease(&probe_stmt, nullptr);
 		if (IsAuthenticationError(msg)) {
 			auto &client_manager = snowflake::SnowflakeClientManager::GetInstance();
-			client_manager.InvalidateConnection(factory->connection->GetConfig());
+			// Don't return this connection to the pool, and drop any idle ones —
+			// the auth token has likely expired for all sessions on this config.
+			factory->lease.Invalidate();
+			client_manager.DrainIdle(factory->lease->GetConfig());
 			throw IOException(msg + "\n\nThe authentication token may have expired. "
 			                        "Please retry your query - a fresh connection will be established automatically.");
 		}
@@ -305,7 +311,7 @@ void SnowflakeGetArrowSchemaViaQuery(SnowflakeArrowStreamFactory *factory, Arrow
 void SnowflakeExecuteAndCacheStream(SnowflakeArrowStreamFactory *factory, ArrowSchema &schema) {
 	AdbcError error;
 	std::memset(&error, 0, sizeof(error));
-	AdbcStatusCode status = AdbcStatementNew(factory->connection->GetConnection(), &factory->statement, &error);
+	AdbcStatusCode status = AdbcStatementNew(factory->lease->GetConnection(), &factory->statement, &error);
 	if (status != ADBC_STATUS_OK) {
 		throw IOException("Failed to create statement for snowflake_query");
 	}
@@ -335,7 +341,10 @@ void SnowflakeExecuteAndCacheStream(SnowflakeArrowStreamFactory *factory, ArrowS
 		}
 		if (IsAuthenticationError(msg)) {
 			auto &client_manager = snowflake::SnowflakeClientManager::GetInstance();
-			client_manager.InvalidateConnection(factory->connection->GetConfig());
+			// Don't return this connection to the pool, and drop any idle ones —
+			// the auth token has likely expired for all sessions on this config.
+			factory->lease.Invalidate();
+			client_manager.DrainIdle(factory->lease->GetConfig());
 			DPRINT("Authentication error detected, connection invalidated for retry\n");
 			throw IOException(msg + "\n\nThe authentication token may have expired. "
 			                        "Please retry your query - a fresh connection will be established automatically.");

--- a/src/snowflake_client_manager.cpp
+++ b/src/snowflake_client_manager.cpp
@@ -4,66 +4,82 @@
 namespace duckdb {
 namespace snowflake {
 
+ConnectionLease::~ConnectionLease() {
+	Reset();
+}
+
+void ConnectionLease::Reset() {
+	if (client && manager) {
+		manager->Return(config, std::move(client), reusable);
+	}
+	manager = nullptr;
+	client = nullptr;
+}
+
 SnowflakeClientManager &SnowflakeClientManager::GetInstance() {
 	static SnowflakeClientManager instance;
 	return instance;
 }
 
-shared_ptr<SnowflakeClient> SnowflakeClientManager::GetConnection(const SnowflakeConfig &config) {
-	std::lock_guard<std::mutex> lock(connection_mutex);
-
-	auto it = connections.find(config);
-	if (it != connections.end() && it->second->IsConnected()) {
-		// Validate the connection is still alive (handles token expiration)
-		if (it->second->TestConnection()) {
-			DPRINT("Reusing existing valid connection\n");
-			return it->second;
+ConnectionLease SnowflakeClientManager::Acquire(const SnowflakeConfig &config) {
+	// Try to reuse an idle connection for this config.
+	shared_ptr<SnowflakeClient> client;
+	{
+		std::lock_guard<std::mutex> lock(pool_mutex);
+		auto it = idle_connections.find(config);
+		if (it != idle_connections.end() && !it->second.empty()) {
+			client = std::move(it->second.back());
+			it->second.pop_back();
 		}
-		// Connection is stale (e.g., token expired), remove it
-		DPRINT("Cached connection is stale, removing and creating new connection\n");
-		connections.erase(it);
 	}
 
-	// Create new connection
+	if (client) {
+		// Validate the reused connection outside the pool lock (TestConnection may
+		// do a round-trip). If it's stale (e.g. token expired) drop it and create
+		// a fresh one below.
+		if (client->IsConnected() && client->TestConnection()) {
+			DPRINT("Reusing pooled Snowflake connection\n");
+			return ConnectionLease(*this, config, std::move(client));
+		}
+		DPRINT("Pooled connection is stale, discarding and reconnecting\n");
+		client.reset();
+	}
+
+	// No usable idle connection — create a dedicated one.
 	DPRINT("Creating new Snowflake connection\n");
-	auto connection = make_shared_ptr<SnowflakeClient>();
-	connection->Connect(config);
-
-	connections[config] = connection;
-	return connection;
+	client = make_shared_ptr<SnowflakeClient>();
+	client->Connect(config);
+	return ConnectionLease(*this, config, std::move(client));
 }
 
-void SnowflakeClientManager::ReleaseConnection(const SnowflakeConfig &config) {
-	std::lock_guard<std::mutex> lock(connection_mutex);
-	connections.erase(config);
-}
-
-void SnowflakeClientManager::InvalidateConnection(const SnowflakeConfig &config) {
-	std::lock_guard<std::mutex> lock(connection_mutex);
-	auto it = connections.find(config);
-	if (it != connections.end()) {
-		DPRINT("Invalidating cached connection (auth error or expiration)\n");
-		connections.erase(it);
+void SnowflakeClientManager::Return(const SnowflakeConfig &config, shared_ptr<SnowflakeClient> client, bool reusable) {
+	if (!client) {
+		return;
 	}
+	if (!reusable || !client->IsConnected()) {
+		// Not reusable (auth error) or already disconnected: let it be torn down
+		// (the by-value `client` disconnects when destroyed after this returns).
+		return;
+	}
+	std::lock_guard<std::mutex> lock(pool_mutex);
+	auto &idle = idle_connections[config];
+	if (idle.size() < MAX_IDLE_PER_CONFIG) {
+		idle.push_back(std::move(client));
+	}
+	// Over the idle cap: drop it (destroyed after the lock is released).
 }
 
-shared_ptr<SnowflakeClient> SnowflakeClientManager::GetFreshConnection(const SnowflakeConfig &config) {
-	std::lock_guard<std::mutex> lock(connection_mutex);
-
-	// Remove any existing connection
-	auto it = connections.find(config);
-	if (it != connections.end()) {
-		DPRINT("Removing existing connection to create fresh one\n");
-		connections.erase(it);
+void SnowflakeClientManager::DrainIdle(const SnowflakeConfig &config) {
+	std::vector<shared_ptr<SnowflakeClient>> to_close;
+	{
+		std::lock_guard<std::mutex> lock(pool_mutex);
+		auto it = idle_connections.find(config);
+		if (it != idle_connections.end()) {
+			to_close = std::move(it->second);
+			idle_connections.erase(it);
+		}
 	}
-
-	// Create new connection
-	DPRINT("Creating fresh Snowflake connection\n");
-	auto connection = make_shared_ptr<SnowflakeClient>();
-	connection->Connect(config);
-
-	connections[config] = connection;
-	return connection;
+	// Destroy (disconnect) the drained connections outside the lock.
 }
 
 } // namespace snowflake

--- a/src/snowflake_scan.cpp
+++ b/src/snowflake_scan.cpp
@@ -37,17 +37,17 @@ static unique_ptr<FunctionData> SnowflakeScanBind(ClientContext &context, TableF
 	// Get client manager
 	auto &client_manager = SnowflakeClientManager::GetInstance();
 
-	shared_ptr<SnowflakeClient> connection;
+	ConnectionLease lease;
 	try {
-		connection = client_manager.GetConnection(config);
+		lease = client_manager.Acquire(config);
 	} catch (const std::exception &e) {
 		throw BinderException("Unexpected error connecting to Snowflake with profile '%s': %s", profile.c_str(),
 		                      e.what());
 	}
 
-	// Create the factory that will manage the ADBC connection and statement
-	// This factory will be kept alive throughout the scan operation
-	auto factory = make_uniq<SnowflakeArrowStreamFactory>(connection, query);
+	// Create the factory that will manage the ADBC connection and statement.
+	// The factory owns the leased connection for the whole scan operation.
+	auto factory = make_uniq<SnowflakeArrowStreamFactory>(std::move(lease), query);
 
 	// Create the bind data that inherits from ArrowScanFunctionData
 	// This allows us to use DuckDB's native Arrow scan implementation

--- a/src/snowflake_secrets.cpp
+++ b/src/snowflake_secrets.cpp
@@ -218,8 +218,8 @@ bool SnowflakeSecretsHelper::ValidateCredentials(ClientContext &context, const s
 		auto &client_manager = snowflake::SnowflakeClientManager::GetInstance();
 
 		try {
-			// Try to get a connection - this will validate the credentials
-			auto connection = client_manager.GetConnection(config);
+			// Lease a connection from the pool - this validates the credentials
+			auto lease = client_manager.Acquire(config);
 
 			// If we got here, connection succeeded - test with a simple query
 			AdbcStatement statement;
@@ -227,7 +227,7 @@ bool SnowflakeSecretsHelper::ValidateCredentials(ClientContext &context, const s
 			std::memset(&error_obj, 0, sizeof(error_obj));
 			std::memset(&statement, 0, sizeof(statement));
 
-			AdbcStatusCode status = AdbcStatementNew(connection->GetConnection(), &statement, &error_obj);
+			AdbcStatusCode status = AdbcStatementNew(lease->GetConnection(), &statement, &error_obj);
 			if (status != ADBC_STATUS_OK) {
 				if (error_obj.release) {
 					error_obj.release(&error_obj);
@@ -297,8 +297,8 @@ bool SnowflakeSecretsHelper::ValidateCredentials(ClientContext &context, const s
 		auto &client_manager = snowflake::SnowflakeClientManager::GetInstance();
 
 		try {
-			// Try to get a connection - this will validate the credentials
-			auto connection = client_manager.GetConnection(config);
+			// Lease a connection from the pool - this validates the credentials
+			auto lease = client_manager.Acquire(config);
 
 			// If we got here, connection succeeded
 			// Test with a simple query to be sure
@@ -307,7 +307,7 @@ bool SnowflakeSecretsHelper::ValidateCredentials(ClientContext &context, const s
 			std::memset(&error_obj, 0, sizeof(error_obj));
 			std::memset(&statement, 0, sizeof(statement));
 
-			AdbcStatusCode status = AdbcStatementNew(connection->GetConnection(), &statement, &error_obj);
+			AdbcStatusCode status = AdbcStatementNew(lease->GetConnection(), &statement, &error_obj);
 			if (status != ADBC_STATUS_OK) {
 				if (error_obj.release) {
 					error_obj.release(&error_obj);

--- a/src/storage/snowflake_catalog.cpp
+++ b/src/storage/snowflake_catalog.cpp
@@ -8,10 +8,12 @@ namespace snowflake {
 
 SnowflakeCatalog::SnowflakeCatalog(AttachedDatabase &db_p, const SnowflakeConfig &config,
                                    const SnowflakeOptions &options_p)
-    : Catalog(db_p), client(SnowflakeClientManager::GetInstance().GetConnection(config)), schemas(*this, client),
-      options(options_p) {
+    : Catalog(db_p), config(config), schemas(*this, config), options(options_p) {
 	DPRINT("SnowflakeCatalog constructor called\n");
-	if (!client || !client->IsConnected()) {
+	// Validate connectivity at ATTACH time. The validated connection is returned
+	// to the pool for reuse when this lease goes out of scope.
+	auto lease = SnowflakeClientManager::GetInstance().Acquire(config);
+	if (!lease || !lease->IsConnected()) {
 		throw ConnectionException("Failed to connect to Snowflake");
 	}
 	DPRINT("SnowflakeCatalog connected successfully with enable_pushdown=%s\n",
@@ -19,10 +21,9 @@ SnowflakeCatalog::SnowflakeCatalog(AttachedDatabase &db_p, const SnowflakeConfig
 }
 
 SnowflakeCatalog::~SnowflakeCatalog() {
-	// TODO consider adding option to allow connections to persist if user wants
-	// to DETACH and ATTACH multiple times
-	auto &client_manager = SnowflakeClientManager::GetInstance();
-	client_manager.ReleaseConnection(client->GetConfig());
+	// Close idle pooled connections for this config on DETACH. Scans still in
+	// flight keep their own leased connection alive until they finish.
+	SnowflakeClientManager::GetInstance().DrainIdle(config);
 }
 
 void SnowflakeCatalog::Initialize(bool load_builtin) {
@@ -48,7 +49,7 @@ optional_ptr<SchemaCatalogEntry> SnowflakeCatalog::LookupSchema(CatalogTransacti
 	// With ATTACH, the database is fixed by the secret; queries must be
 	// catalog.schema.table.
 	if (schema_name.find('.') != string::npos) {
-		const auto &attached_db = client->GetConfig().database;
+		const auto &attached_db = config.database;
 		const auto &alias = GetName();
 		throw BinderException("Invalid path: you are trying to reference '%s' while a database is "
 		                      "already attached (\"%s\").\n"
@@ -63,7 +64,7 @@ optional_ptr<SchemaCatalogEntry> SnowflakeCatalog::LookupSchema(CatalogTransacti
 
 	auto found_entry = schemas.GetEntry(transaction.GetContext(), schema_name);
 	if (!found_entry && if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
-		const auto &attached_db = client->GetConfig().database;
+		const auto &attached_db = config.database;
 		throw BinderException("Schema '%s' not found in attached database '%s'. To query a different "
 		                      "database, create a separate ATTACH or use snowflake_query().",
 		                      schema_name.c_str(), attached_db.c_str());
@@ -89,7 +90,6 @@ bool SnowflakeCatalog::InMemory() {
 
 string SnowflakeCatalog::GetDBPath() {
 	// Return a descriptive path for the Snowflake database
-	const auto &config = client->GetConfig();
 	return config.account + "." + config.database;
 }
 

--- a/src/storage/snowflake_schema_entry.cpp
+++ b/src/storage/snowflake_schema_entry.cpp
@@ -6,10 +6,10 @@ namespace duckdb {
 namespace snowflake {
 
 SnowflakeSchemaEntry::SnowflakeSchemaEntry(Catalog &catalog, const string &schema_name, CreateSchemaInfo &info,
-                                           const shared_ptr<SnowflakeClient> &client)
-    : SchemaCatalogEntry(catalog, info), client(client) {
+                                           const SnowflakeConfig &config)
+    : SchemaCatalogEntry(catalog, info), config(config) {
 	name = schema_name;
-	tables = make_uniq<SnowflakeTableSet>(*this, client, schema_name);
+	tables = make_uniq<SnowflakeTableSet>(*this, config, schema_name);
 }
 
 optional_ptr<CatalogEntry> SnowflakeSchemaEntry::LookupEntry(CatalogTransaction transaction,

--- a/src/storage/snowflake_schema_set.cpp
+++ b/src/storage/snowflake_schema_set.cpp
@@ -1,19 +1,21 @@
 #include "storage/snowflake_schema_set.hpp"
 #include "storage/snowflake_table_set.hpp"
+#include "snowflake_client_manager.hpp"
 #include "snowflake_debug.hpp"
 
 namespace duckdb {
 namespace snowflake {
 void SnowflakeSchemaSet::LoadEntries(ClientContext &context) {
 	DPRINT("SnowflakeSchemaSet::LoadEntries called\n");
-	vector<string> schema_names = client->ListSchemas(context);
+	auto lease = SnowflakeClientManager::GetInstance().Acquire(config);
+	vector<string> schema_names = lease->ListSchemas(context);
 	DPRINT("Got %zu schemas from ListSchemas\n", schema_names.size());
 
 	for (const auto &schema_name : schema_names) {
 		DPRINT("Creating schema entry for: %s\n", schema_name.c_str());
 		auto schema_info = make_uniq<CreateSchemaInfo>();
 		schema_info->schema = schema_name;
-		auto schema_entry = make_uniq<SnowflakeSchemaEntry>(catalog, schema_name, *schema_info, client);
+		auto schema_entry = make_uniq<SnowflakeSchemaEntry>(catalog, schema_name, *schema_info, config);
 		entries.insert({schema_name, std::move(schema_entry)});
 	}
 	DPRINT("SnowflakeSchemaSet::LoadEntries completed with %zu entries\n", entries.size());

--- a/src/storage/snowflake_table_entry.cpp
+++ b/src/storage/snowflake_table_entry.cpp
@@ -26,21 +26,21 @@ static void CloneCachedSchema(ArrowSchema &src, ArrowSchema &dst) {
 }
 
 TableFunction SnowflakeTableEntry::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) {
-	DPRINT("SnowflakeTableEntry::GetScanFunction called for table %s.%s.%s\n", client->GetConfig().database.c_str(),
+	DPRINT("SnowflakeTableEntry::GetScanFunction called for table %s.%s.%s\n", GetConfig().database.c_str(),
 	       schema.name.c_str(), name.c_str());
 
-	auto &config = client->GetConfig();
+	auto &config = GetConfig();
 	string query = "SELECT * FROM " + QuoteSnowflakeIdentifier(config.database) + "." +
 	               QuoteSnowflakeIdentifier(schema.name) + "." + QuoteSnowflakeIdentifier(name);
 	DPRINT("SnowflakeTableEntry: Query = '%s'\n", query.c_str());
 
-	// TODO consider maintaining a thread-safe pool of connections in client, so
-	// we can use the client within SnowflakeTableEntry instead of creating a new
-	// client
+	// Lease a dedicated connection from the pool for this scan; it is owned by the
+	// factory and returned to the pool when the bound query is torn down. This is
+	// what keeps concurrent scans from sharing one non-thread-safe ADBC connection.
 	auto &client_manager = SnowflakeClientManager::GetInstance();
-	auto connection = client_manager.GetConnection(config);
+	auto lease = client_manager.Acquire(config);
 
-	auto factory = make_uniq<SnowflakeArrowStreamFactory>(connection, query);
+	auto factory = make_uniq<SnowflakeArrowStreamFactory>(std::move(lease), query);
 	DPRINT("SnowflakeTableEntry: Created factory at %p\n", (void *)factory.get());
 
 	// Apply pushdown settings from catalog options

--- a/src/storage/snowflake_table_set.cpp
+++ b/src/storage/snowflake_table_set.cpp
@@ -1,11 +1,13 @@
 #include "storage/snowflake_table_set.hpp"
 #include "storage/snowflake_table_entry.hpp"
+#include "snowflake_client_manager.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 
 namespace duckdb {
 namespace snowflake {
 void SnowflakeTableSet::LoadEntries(ClientContext &context) {
-	auto table_names = client->ListTables(context, schema_name);
+	auto lease = SnowflakeClientManager::GetInstance().Acquire(config);
+	auto table_names = lease->ListTables(context, schema_name);
 
 	for (const auto &table_name : table_names) {
 		CreateTableInfo info;
@@ -15,7 +17,7 @@ void SnowflakeTableSet::LoadEntries(ClientContext &context) {
 		info.on_conflict = OnCreateConflict::IGNORE_ON_CONFLICT;
 		info.temporary = false;
 
-		auto table_entry = make_uniq<SnowflakeTableEntry>(schema.catalog, schema, info, client);
+		auto table_entry = make_uniq<SnowflakeTableEntry>(schema.catalog, schema, info, config);
 
 		entries[table_name] = std::move(table_entry);
 	}

--- a/test/sql/snowflake_concurrent_scans.test
+++ b/test/sql/snowflake_concurrent_scans.test
@@ -1,0 +1,56 @@
+# name: test/sql/snowflake_concurrent_scans.test
+# description: Concurrent scans each lease their own pooled connection (regression test for the shared-connection data race)
+# group: [sql]
+
+# Before the connection pool, every concurrent scan drove the same cached ADBC
+# connection; ADBC connections are not thread-safe, so this crashed
+# intermittently (SIGSEGV) under dbt-style workloads. Eight threads scanning
+# simultaneously exercise Acquire()/Return() under contention; each thread
+# must get its own connection and correct results.
+
+require snowflake
+
+require-env SNOWFLAKE_ACCOUNT
+
+require-env SNOWFLAKE_USERNAME
+
+require-env SNOWFLAKE_PRIVATE_KEY_FILE
+
+require-env SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE
+
+require-env SNOWFLAKE_DATABASE
+
+statement ok
+CREATE SECRET sf_concurrent (
+    TYPE snowflake,
+    ACCOUNT '${SNOWFLAKE_ACCOUNT}',
+    USER '${SNOWFLAKE_USERNAME}',
+    AUTH_TYPE 'key_pair',
+    PRIVATE_KEY_FILE '${SNOWFLAKE_PRIVATE_KEY_FILE}',
+    PRIVATE_KEY_PASSWORD '${SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE}',
+    DATABASE '${SNOWFLAKE_DATABASE}',
+    WAREHOUSE 'COMPUTE_WH'
+);
+
+statement ok
+ATTACH '' AS sf_pool (TYPE SNOWFLAKE, SECRET sf_concurrent, READ_ONLY);
+
+concurrentloop i 0 8
+
+query I
+SELECT count(N_NATIONKEY) FROM sf_pool.TPCH_SF1.NATION;
+----
+25
+
+query I
+SELECT count(R_REGIONKEY) FROM sf_pool.TPCH_SF1.REGION;
+----
+5
+
+endloop
+
+# Pool sanity after the storm: a fresh scan on the same session still works
+query I
+SELECT count(N_NATIONKEY) FROM sf_pool.TPCH_SF1.NATION;
+----
+25

--- a/test/sql/snowflake_connection_failure.test
+++ b/test/sql/snowflake_connection_failure.test
@@ -1,0 +1,42 @@
+# name: test/sql/snowflake_connection_failure.test
+# description: Connection refusal fails as a clean statement error, never a crash
+# group: [sql]
+
+# When Snowflake refuses a connection (bad account, exhausted capacity, auth
+# rejection), SnowflakeClientManager::Acquire() must surface a thrown DuckDB
+# exception — a normal statement error — and the session must stay usable.
+# Acquire() never blocks: it either returns a lease or throws (there are no
+# waiting primitives in the pool), so a refusal can't hang a query either.
+#
+# This test needs no Snowflake credentials: the account is intentionally
+# nonexistent, so the driver's login request fails fast (HTTP 404).
+
+require snowflake
+
+statement ok
+CREATE SECRET bad_sf (
+    TYPE snowflake,
+    ACCOUNT 'NONEXISTENT-ACCOUNT99999',
+    USER 'nobody',
+    PASSWORD 'wrong',
+    DATABASE 'X',
+    WAREHOUSE 'X'
+);
+
+# snowflake_query path: Acquire() throws -> BinderException with context
+statement error
+SELECT * FROM snowflake_query('SELECT 1', 'bad_sf');
+----
+<REGEX>:.*Unexpected error connecting to Snowflake.*
+
+# ATTACH path: connect failure surfaces as a statement-level IO error
+statement error
+ATTACH '' AS bad_db (TYPE SNOWFLAKE, SECRET bad_sf, READ_ONLY);
+----
+<REGEX>:.*Failed to initialize connection.*
+
+# The session survives both refusals — no crash, no poisoned state
+query I
+SELECT 42;
+----
+42


### PR DESCRIPTION
This PR fixes a data race that can crash the process (SIGSEGV) whenever the extension is used concurrently, which in practice covers most real workloads. The most common trigger I've seen is **dbt-duckdb**: it runs each model on its own cursor of a single shared DuckDB connection, so two models reading Snowflake at the same time (or even one model that scans the same Snowflake table twice, like a self-join or `UNION ALL`) end up going through the *same* Snowflake connection at the *same* moment.

## The problem

The extension keeps **one** `SnowflakeClient` (one ADBC connection) per set of credentials, cached process-wide in `SnowflakeClientManager`, and every scan and every catalog lookup uses it. But an ADBC connection is explicitly **not thread-safe**: the ADBC spec says the caller has to serialize access to it, and right now the extension doesn't. So two concurrent scans call `AdbcStatementExecuteQuery` and pull Arrow batches on the same connection at once, quietly corrupt the driver's internal state, and the process falls over some time later, frequently in a totally unrelated model. That "crash lands somewhere else" behaviour is exactly why it has shown up as intermittent, non-reproducible segfaults.

The current code already half-knew about this. There is a `// Don't fetch row count to avoid ADBC statement conflicts` note in `snowflake_table_entry.cpp`, and a `TODO` about wanting a connection pool.

One important constraint: a lock around the single connection is not enough. A single DuckDB query can legitimately hold two Snowflake scan streams open and being read at the same time (for example `UNION ALL` over the same table when `preserve_insertion_order` is off). Serializing one shared connection there either kills all parallelism or deadlocks. Concurrent scans genuinely need **separate connections**.

## The fix

Turn the single cached connection into a small **connection pool**, keyed by credentials:

- `SnowflakeClientManager` now hands out a *dedicated* connection per active scan through a tiny RAII helper, `ConnectionLease`. When the scan finishes, the connection returns to a per-config idle list and gets reused, so there is no reconnect storm.
- Each scan factory (`SnowflakeArrowStreamFactory`) owns its lease for the life of the scan, so its Arrow stream and ADBC statement run on a connection nothing else touches.
- The catalog paths (`ListSchemas`, `ListTables`, `GetTableInfo`) and secret validation briefly lease their own connection too, instead of sharing one, so metadata calls cannot race a running scan either.

> **One deliberate design point:** there is a cap on the number of *idle* connections kept for reuse, but **no cap on active** ones. Because a single query can need several open Snowflake streams at once, capping active leases would deadlock. Only the idle pool is bounded.

More concurrency does mean more Snowflake sessions, but that is expected and normal. It is the same thing the native `dbt-snowflake` adapter does (one session per thread), and idle sessions are reused rather than reconnected.

## How it was verified

I don't have a live Snowflake account handy, so instead I built a small **mock ADBC "Snowflake" driver**. The extension `dlopen`s its ADBC driver from a path, so it can be pointed at a fake one that returns canned Arrow data. I then drove the *real* extension and *real* DuckDB (built at this repo's pinned commit) under **ThreadSanitizer**:

| scenario | before | after |
| --- | --- | --- |
| concurrent scans (dbt-style: several cursors on one DuckDB connection) | 30 data races, crash | **0 races** |
| one query, two scans of the same table (`UNION ALL`) | real races, crash | **0 races** |

It is also clean under AddressSanitizer and returns identical results to before. To make sure the sanitizer wasn't simply hiding things, I confirmed the **unpatched** code still trips it when DuckDB itself is built with the sanitizer (it does), and that this change drives it to zero.

What I did **not** do: run it against the repo's own CI or a live Snowflake account. So a careful second look at the auth-error / token-expiry reconnect path, and at the connection-lifetime ordering in `~SnowflakeArrowStreamFactory` (statement and stream released before the lease returns the connection), would be very welcome.

---

For a bit of context: I'm a developer at **DuckDB Labs**, and a couple of users hit this in production through dbt-duckdb. Happy to iterate on naming, the idle-pool cap, or anything else you'd like changed.
