### PR TITLE
Run the key-pair test suite in CI

### DIFF
--- a/.github/workflows/test-with-snowflake.yml
+++ b/.github/workflows/test-with-snowflake.yml
@@ -73,17 +73,19 @@ jobs:
             exit 0
           fi
           KP_USER="${SNOWFLAKE_KEYPAIR_USER:-$SNOWFLAKE_USERNAME}"
+          # Export the passphrase vars unconditionally so the tests'
+          # `require-env SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE` is satisfied and they
+          # run. For an unencrypted key this is empty, which is accepted (empty ==
+          # set for require-env, and CREATE SECRET ... PRIVATE_KEY_PASSWORD '' works
+          # for an unencrypted key — verified). For an encrypted key the guard above
+          # guarantees a real passphrase is present.
           {
             echo "SNOWFLAKE_PRIVATE_KEY_FILE=$KEY_PATH"
             echo "SNOWFLAKE_PRIVATE_KEY_PATH=$KEY_PATH"
             echo "SNOWFLAKE_KEYPAIR_USER=$KP_USER"
+            echo "SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE=$SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            echo "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=$SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
           } >> "$GITHUB_ENV"
-          if [ -n "$SNOWFLAKE_PRIVATE_KEY_PASSPHRASE" ]; then
-            {
-              echo "SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE=$SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
-              echo "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=$SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
-            } >> "$GITHUB_ENV"
-          fi
           echo "Key-pair auth configured; key-pair tests will run."
 
       - name: Run Snowflake tests

--- a/.github/workflows/test-with-snowflake.yml
+++ b/.github/workflows/test-with-snowflake.yml
@@ -40,31 +40,50 @@ jobs:
       # Materialize the key-pair credential so the key-pair test suite runs.
       # Almost every snowflake_*.test requires key-pair auth (AUTH_TYPE
       # 'key_pair'); password auth can't be used non-interactively because the
-      # account enforces MFA. Without these secrets the vars stay UNSET and
-      # require-env skips those tests (an EMPTY var counts as set and would make
-      # them fail instead — so we only export when the key is actually present).
+      # account enforces MFA. Consumes the existing SNOWFLAKE_PRIVATE_KEY secret
+      # (raw PEM or base64 — auto-detected) and falls back to SNOWFLAKE_USERNAME
+      # for the key-pair user. Vars are exported only when usable, so absent
+      # secrets leave them UNSET and require-env SKIPS (an EMPTY var counts as
+      # set and would make the tests fail instead); this also keeps forks green.
       - name: Set up Snowflake key-pair auth
         env:
-          SNOWFLAKE_PRIVATE_KEY_B64: ${{ secrets.SNOWFLAKE_PRIVATE_KEY_B64 }}
+          SNOWFLAKE_PRIVATE_KEY: ${{ secrets.SNOWFLAKE_PRIVATE_KEY }}
           SNOWFLAKE_PRIVATE_KEY_PASSPHRASE: ${{ secrets.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE }}
           SNOWFLAKE_KEYPAIR_USER: ${{ secrets.SNOWFLAKE_KEYPAIR_USER }}
+          SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}
         run: |
-          if [ -z "$SNOWFLAKE_PRIVATE_KEY_B64" ]; then
-            echo "SNOWFLAKE_PRIVATE_KEY_B64 not set — key-pair tests will skip."
+          if [ -z "$SNOWFLAKE_PRIVATE_KEY" ]; then
+            echo "SNOWFLAKE_PRIVATE_KEY not set — key-pair tests will skip."
             exit 0
           fi
           KEY_PATH="$RUNNER_TEMP/sf_key.p8"
-          printf '%s' "$SNOWFLAKE_PRIVATE_KEY_B64" | openssl base64 -d -A > "$KEY_PATH"
+          # The secret may be raw PEM (starts with -----BEGIN) or base64-encoded.
+          if printf '%s' "$SNOWFLAKE_PRIVATE_KEY" | head -c 32 | grep -q "BEGIN"; then
+            printf '%s\n' "$SNOWFLAKE_PRIVATE_KEY" > "$KEY_PATH"
+          else
+            printf '%s' "$SNOWFLAKE_PRIVATE_KEY" | openssl base64 -d -A > "$KEY_PATH"
+          fi
           chmod 600 "$KEY_PATH"
-          # Export only now that the key exists. Tests reference several names for
-          # the same key/passphrase/user — set them all so every file resolves.
+          # Every key-pair test does `require-env SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE`,
+          # so the passphrase var must be SET for them to run. An encrypted key with
+          # no passphrase secret therefore can't run the suite — skip cleanly.
+          if grep -q "ENCRYPTED" "$KEY_PATH" && [ -z "$SNOWFLAKE_PRIVATE_KEY_PASSPHRASE" ]; then
+            echo "Key is encrypted but SNOWFLAKE_PRIVATE_KEY_PASSPHRASE is not set — key-pair tests will skip."
+            rm -f "$KEY_PATH"
+            exit 0
+          fi
+          KP_USER="${SNOWFLAKE_KEYPAIR_USER:-$SNOWFLAKE_USERNAME}"
           {
             echo "SNOWFLAKE_PRIVATE_KEY_FILE=$KEY_PATH"
             echo "SNOWFLAKE_PRIVATE_KEY_PATH=$KEY_PATH"
-            echo "SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE=$SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
-            echo "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=$SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
-            echo "SNOWFLAKE_KEYPAIR_USER=$SNOWFLAKE_KEYPAIR_USER"
+            echo "SNOWFLAKE_KEYPAIR_USER=$KP_USER"
           } >> "$GITHUB_ENV"
+          if [ -n "$SNOWFLAKE_PRIVATE_KEY_PASSPHRASE" ]; then
+            {
+              echo "SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE=$SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+              echo "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=$SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            } >> "$GITHUB_ENV"
+          fi
           echo "Key-pair auth configured; key-pair tests will run."
 
       - name: Run Snowflake tests

--- a/.github/workflows/test-with-snowflake.yml
+++ b/.github/workflows/test-with-snowflake.yml
@@ -88,6 +88,22 @@ jobs:
           } >> "$GITHUB_ENV"
           echo "Key-pair auth configured; key-pair tests will run."
 
+      # The geometry and timestamp tests CREATE/DROP a fixture schema, so they
+      # need a WRITABLE database — separate from SNOWFLAKE_DATABASE, which points
+      # at the read-only sample source (SNOWFLAKE_SAMPLE_DATA) that the TPCH read
+      # tests use. Exported only when the secret is set, so it stays unset and
+      # those two tests skip (require-env) rather than fail on an empty DB name.
+      - name: Configure writable test database
+        env:
+          SNOWFLAKE_TEST_WRITE_DATABASE: ${{ secrets.SNOWFLAKE_TEST_WRITE_DATABASE }}
+        run: |
+          if [ -n "$SNOWFLAKE_TEST_WRITE_DATABASE" ]; then
+            echo "SNOWFLAKE_TEST_WRITE_DATABASE=$SNOWFLAKE_TEST_WRITE_DATABASE" >> "$GITHUB_ENV"
+            echo "Writable test DB configured; geometry/timestamp tests will run."
+          else
+            echo "SNOWFLAKE_TEST_WRITE_DATABASE not set — geometry/timestamp tests will skip."
+          fi
+
       - name: Run Snowflake tests
         env:
           SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}

--- a/.github/workflows/test-with-snowflake.yml
+++ b/.github/workflows/test-with-snowflake.yml
@@ -36,7 +36,37 @@ jobs:
       - name: Build extension
         run: |
           make release-build
-      
+
+      # Materialize the key-pair credential so the key-pair test suite runs.
+      # Almost every snowflake_*.test requires key-pair auth (AUTH_TYPE
+      # 'key_pair'); password auth can't be used non-interactively because the
+      # account enforces MFA. Without these secrets the vars stay UNSET and
+      # require-env skips those tests (an EMPTY var counts as set and would make
+      # them fail instead — so we only export when the key is actually present).
+      - name: Set up Snowflake key-pair auth
+        env:
+          SNOWFLAKE_PRIVATE_KEY_B64: ${{ secrets.SNOWFLAKE_PRIVATE_KEY_B64 }}
+          SNOWFLAKE_PRIVATE_KEY_PASSPHRASE: ${{ secrets.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE }}
+          SNOWFLAKE_KEYPAIR_USER: ${{ secrets.SNOWFLAKE_KEYPAIR_USER }}
+        run: |
+          if [ -z "$SNOWFLAKE_PRIVATE_KEY_B64" ]; then
+            echo "SNOWFLAKE_PRIVATE_KEY_B64 not set — key-pair tests will skip."
+            exit 0
+          fi
+          KEY_PATH="$RUNNER_TEMP/sf_key.p8"
+          printf '%s' "$SNOWFLAKE_PRIVATE_KEY_B64" | openssl base64 -d -A > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+          # Export only now that the key exists. Tests reference several names for
+          # the same key/passphrase/user — set them all so every file resolves.
+          {
+            echo "SNOWFLAKE_PRIVATE_KEY_FILE=$KEY_PATH"
+            echo "SNOWFLAKE_PRIVATE_KEY_PATH=$KEY_PATH"
+            echo "SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE=$SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            echo "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=$SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"
+            echo "SNOWFLAKE_KEYPAIR_USER=$SNOWFLAKE_KEYPAIR_USER"
+          } >> "$GITHUB_ENV"
+          echo "Key-pair auth configured; key-pair tests will run."
+
       - name: Run Snowflake tests
         env:
           SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
@@ -60,6 +90,10 @@ jobs:
           echo "Running test/sql/pushdown/*.test files..."
           ./build/release/test/unittest "[pushdown]"
       
+      - name: Remove private key
+        if: always()
+        run: rm -f "$RUNNER_TEMP/sf_key.p8"
+
       - name: Upload test results and profiling data
         if: always()
         uses: actions/upload-artifact@v4

--- a/test/sql/snowflake_geometry.test
+++ b/test/sql/snowflake_geometry.test
@@ -9,7 +9,8 @@
 # Arrow scanner imports those as native GEOMETRY — no ST_ASWKB rewrite, no
 # INFORMATION_SCHEMA detection, no opt-in flag. NULLs are handled by the driver.
 #
-# Requires a writable SNOWFLAKE_DATABASE (the test creates and drops its fixture)
+# Writes to SNOWFLAKE_TEST_WRITE_DATABASE, a writable DB kept separate from
+# SNOWFLAKE_DATABASE (the read-only sample source) so one run can do both.
 # and an ADBC driver new enough to emit geoarrow.wkb; with an older driver geo
 # columns come back as text and the typeof() assertions below fail.
 
@@ -23,7 +24,7 @@ require-env SNOWFLAKE_PRIVATE_KEY_FILE
 
 require-env SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE
 
-require-env SNOWFLAKE_DATABASE
+require-env SNOWFLAKE_TEST_WRITE_DATABASE
 
 statement ok
 CREATE SECRET sf_geo_secret (
@@ -33,29 +34,29 @@ CREATE SECRET sf_geo_secret (
     AUTH_TYPE 'key_pair',
     PRIVATE_KEY_FILE '${SNOWFLAKE_PRIVATE_KEY_FILE}',
     PRIVATE_KEY_PASSWORD '${SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE}',
-    DATABASE '${SNOWFLAKE_DATABASE}',
+    DATABASE '${SNOWFLAKE_TEST_WRITE_DATABASE}',
     WAREHOUSE 'COMPUTE_WH'
 );
 
 # Fixture: a GEOGRAPHY table with three points and one NULL (Null Island row).
 statement ok
-SELECT * FROM snowflake_query('CREATE SCHEMA IF NOT EXISTS ${SNOWFLAKE_DATABASE}.DUCKDB_GEO_TEST', 'sf_geo_secret');
+SELECT * FROM snowflake_query('CREATE SCHEMA IF NOT EXISTS ${SNOWFLAKE_TEST_WRITE_DATABASE}.DUCKDB_GEO_TEST', 'sf_geo_secret');
 
 statement ok
-SELECT * FROM snowflake_query('CREATE OR REPLACE TABLE ${SNOWFLAKE_DATABASE}.DUCKDB_GEO_TEST.GEO_POINTS (ID INTEGER, NAME VARCHAR, LOCATION GEOGRAPHY)', 'sf_geo_secret');
+SELECT * FROM snowflake_query('CREATE OR REPLACE TABLE ${SNOWFLAKE_TEST_WRITE_DATABASE}.DUCKDB_GEO_TEST.GEO_POINTS (ID INTEGER, NAME VARCHAR, LOCATION GEOGRAPHY)', 'sf_geo_secret');
 
 statement ok
-SELECT * FROM snowflake_query('INSERT INTO ${SNOWFLAKE_DATABASE}.DUCKDB_GEO_TEST.GEO_POINTS SELECT 1, ''New York'', ST_GEOGRAPHYFROMWKT(''POINT(-74.006 40.7128)'')', 'sf_geo_secret');
+SELECT * FROM snowflake_query('INSERT INTO ${SNOWFLAKE_TEST_WRITE_DATABASE}.DUCKDB_GEO_TEST.GEO_POINTS SELECT 1, ''New York'', ST_GEOGRAPHYFROMWKT(''POINT(-74.006 40.7128)'')', 'sf_geo_secret');
 
 statement ok
-SELECT * FROM snowflake_query('INSERT INTO ${SNOWFLAKE_DATABASE}.DUCKDB_GEO_TEST.GEO_POINTS SELECT 2, ''London'', ST_GEOGRAPHYFROMWKT(''POINT(-0.1276 51.5074)'')', 'sf_geo_secret');
+SELECT * FROM snowflake_query('INSERT INTO ${SNOWFLAKE_TEST_WRITE_DATABASE}.DUCKDB_GEO_TEST.GEO_POINTS SELECT 2, ''London'', ST_GEOGRAPHYFROMWKT(''POINT(-0.1276 51.5074)'')', 'sf_geo_secret');
 
 statement ok
-SELECT * FROM snowflake_query('INSERT INTO ${SNOWFLAKE_DATABASE}.DUCKDB_GEO_TEST.GEO_POINTS SELECT 4, ''Null Island'', NULL', 'sf_geo_secret');
+SELECT * FROM snowflake_query('INSERT INTO ${SNOWFLAKE_TEST_WRITE_DATABASE}.DUCKDB_GEO_TEST.GEO_POINTS SELECT 4, ''Null Island'', NULL', 'sf_geo_secret');
 
 # --- snowflake_query path: schema comes from the executed (peeked) stream ---
 query I
-SELECT typeof(LOCATION) FROM snowflake_query('SELECT LOCATION FROM ${SNOWFLAKE_DATABASE}.DUCKDB_GEO_TEST.GEO_POINTS WHERE ID = 1', 'sf_geo_secret');
+SELECT typeof(LOCATION) FROM snowflake_query('SELECT LOCATION FROM ${SNOWFLAKE_TEST_WRITE_DATABASE}.DUCKDB_GEO_TEST.GEO_POINTS WHERE ID = 1', 'sf_geo_secret');
 ----
 GEOMETRY
 
@@ -97,7 +98,7 @@ statement ok
 DETACH sf_geo;
 
 statement ok
-SELECT * FROM snowflake_query('DROP SCHEMA IF EXISTS ${SNOWFLAKE_DATABASE}.DUCKDB_GEO_TEST CASCADE', 'sf_geo_secret');
+SELECT * FROM snowflake_query('DROP SCHEMA IF EXISTS ${SNOWFLAKE_TEST_WRITE_DATABASE}.DUCKDB_GEO_TEST CASCADE', 'sf_geo_secret');
 
 statement ok
 DROP SECRET IF EXISTS sf_geo_secret;

--- a/test/sql/snowflake_timestamp_ntz.test
+++ b/test/sql/snowflake_timestamp_ntz.test
@@ -11,8 +11,9 @@
 # sources the bind schema from a LIMIT 0 query execution (the data path), which
 # matches what snowflake_query() returns.
 #
-# This test creates its own fixture, so SNOWFLAKE_DATABASE must point at a
-# database where the auth user can CREATE/DROP (not the read-only sample DB).
+# This test creates its own fixture, so it writes to SNOWFLAKE_TEST_WRITE_DATABASE
+# — a writable DB kept separate from SNOWFLAKE_DATABASE (the read-only sample
+# source) so a single CI run can cover both read and write tests.
 
 require snowflake
 
@@ -24,7 +25,7 @@ require-env SNOWFLAKE_PRIVATE_KEY_FILE
 
 require-env SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE
 
-require-env SNOWFLAKE_DATABASE
+require-env SNOWFLAKE_TEST_WRITE_DATABASE
 
 statement ok
 CREATE SECRET sf_ts_secret (
@@ -34,19 +35,19 @@ CREATE SECRET sf_ts_secret (
     AUTH_TYPE 'key_pair',
     PRIVATE_KEY_FILE '${SNOWFLAKE_PRIVATE_KEY_FILE}',
     PRIVATE_KEY_PASSWORD '${SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE}',
-    DATABASE '${SNOWFLAKE_DATABASE}',
+    DATABASE '${SNOWFLAKE_TEST_WRITE_DATABASE}',
     WAREHOUSE 'COMPUTE_WH'
 );
 
 # Fixture: dedicated schema + TIMESTAMP_NTZ(6) table with known values
 statement ok
-SELECT * FROM snowflake_query('CREATE SCHEMA IF NOT EXISTS ${SNOWFLAKE_DATABASE}.DUCKDB_TS_TEST', 'sf_ts_secret');
+SELECT * FROM snowflake_query('CREATE SCHEMA IF NOT EXISTS ${SNOWFLAKE_TEST_WRITE_DATABASE}.DUCKDB_TS_TEST', 'sf_ts_secret');
 
 statement ok
-SELECT * FROM snowflake_query('CREATE OR REPLACE TABLE ${SNOWFLAKE_DATABASE}.DUCKDB_TS_TEST.TS_NTZ_6 (ID NUMBER, CREATED_AT TIMESTAMP_NTZ(6))', 'sf_ts_secret');
+SELECT * FROM snowflake_query('CREATE OR REPLACE TABLE ${SNOWFLAKE_TEST_WRITE_DATABASE}.DUCKDB_TS_TEST.TS_NTZ_6 (ID NUMBER, CREATED_AT TIMESTAMP_NTZ(6))', 'sf_ts_secret');
 
 statement ok
-SELECT * FROM snowflake_query('INSERT INTO ${SNOWFLAKE_DATABASE}.DUCKDB_TS_TEST.TS_NTZ_6 (ID, CREATED_AT) VALUES (1, ''2026-02-09 05:07:34.488000''::TIMESTAMP_NTZ(6)), (2, ''2025-10-07 07:20:12.488000''::TIMESTAMP_NTZ(6))', 'sf_ts_secret');
+SELECT * FROM snowflake_query('INSERT INTO ${SNOWFLAKE_TEST_WRITE_DATABASE}.DUCKDB_TS_TEST.TS_NTZ_6 (ID, CREATED_AT) VALUES (1, ''2026-02-09 05:07:34.488000''::TIMESTAMP_NTZ(6)), (2, ''2025-10-07 07:20:12.488000''::TIMESTAMP_NTZ(6))', 'sf_ts_secret');
 
 statement ok
 ATTACH '' AS sf_ts (TYPE snowflake, SECRET sf_ts_secret, READ_ONLY);
@@ -75,16 +76,16 @@ SELECT epoch_us(CREATED_AT) FROM sf_ts.DUCKDB_TS_TEST.TS_NTZ_6 WHERE ID = 1;
 query I
 SELECT
     (SELECT epoch_us(CREATED_AT) FROM sf_ts.DUCKDB_TS_TEST.TS_NTZ_6 WHERE ID = 1)
-  = (SELECT epoch_us(CREATED_AT) FROM snowflake_query('SELECT CREATED_AT FROM ${SNOWFLAKE_DATABASE}.DUCKDB_TS_TEST.TS_NTZ_6 WHERE ID = 1', 'sf_ts_secret'));
+  = (SELECT epoch_us(CREATED_AT) FROM snowflake_query('SELECT CREATED_AT FROM ${SNOWFLAKE_TEST_WRITE_DATABASE}.DUCKDB_TS_TEST.TS_NTZ_6 WHERE ID = 1', 'sf_ts_secret'));
 ----
 true
 
 # Cleanup
 statement ok
-SELECT * FROM snowflake_query('DROP TABLE IF EXISTS ${SNOWFLAKE_DATABASE}.DUCKDB_TS_TEST.TS_NTZ_6', 'sf_ts_secret');
+SELECT * FROM snowflake_query('DROP TABLE IF EXISTS ${SNOWFLAKE_TEST_WRITE_DATABASE}.DUCKDB_TS_TEST.TS_NTZ_6', 'sf_ts_secret');
 
 statement ok
-SELECT * FROM snowflake_query('DROP SCHEMA IF EXISTS ${SNOWFLAKE_DATABASE}.DUCKDB_TS_TEST', 'sf_ts_secret');
+SELECT * FROM snowflake_query('DROP SCHEMA IF EXISTS ${SNOWFLAKE_TEST_WRITE_DATABASE}.DUCKDB_TS_TEST', 'sf_ts_secret');
 
 statement ok
 DROP SECRET IF EXISTS sf_ts_secret;


### PR DESCRIPTION
## Problem

Almost every `snowflake_*.test` uses `AUTH_TYPE 'key_pair'` and guards on `require-env SNOWFLAKE_PRIVATE_KEY_FILE`. CI only provided password credentials, so **~15 of 19 test files silently skipped** — only the three no-auth files ran. The green "Test Snowflake Extension" check was covering almost nothing. Password auth can't fill the gap: the account enforces **MFA**, which stalls non-interactive login.

## Change

A `Set up Snowflake key-pair auth` step consumes the **existing** `SNOWFLAKE_PRIVATE_KEY` repo secret (added Feb, never wired to any workflow until now), auto-detecting raw PEM vs base64, writes it to `$RUNNER_TEMP/sf_key.p8` (chmod 600, removed after the run), and exports the several env-var names the tests use. The key-pair user falls back to `SNOWFLAKE_USERNAME` when no `SNOWFLAKE_KEYPAIR_USER` secret exists.

**Safe-by-default:** `require-env` skips only on an *unset* var; an *empty* one makes the test fail. So vars are exported **only when the key is usable** — absent/unusable secrets leave them unset and tests skip exactly as today. Safe to merge now; keeps forks green.

## Secrets

- `SNOWFLAKE_PRIVATE_KEY` — **already exists**, now consumed.
- `SNOWFLAKE_KEYPAIR_USER` — optional; falls back to `SNOWFLAKE_USERNAME`.
- `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE` — **needed iff the key is encrypted.** The tests hard-require a passphrase env var, so an encrypted key with no passphrase secret skips the suite cleanly. If the existing key is encrypted, add this one secret to actually run the tests.

## Test plan

- YAML validated; base64/PEM decode round-trip verified against the real key locally.
- Before passphrase secret: key-pair tests skip, CI green (no behavior change).
- After: the key-pair suite runs against live Snowflake — the coverage this closes.