### PR TITLE
Salvage BUILD/README polish from #43; complete the 0.5.0 CHANGELOG

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -151,7 +151,7 @@ CREATE SECRET test_snowflake (
 query I
 SELECT snowflake_version();
 ----
-Snowflake Extension v0.1.0
+Snowflake Extension v0.5.0
 ```
 
 ### Integration Testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Targets DuckDB **v1.5.4**.
 - Native `GEOMETRY`/`GEOGRAPHY` support: Snowflake geo columns are returned as GeoArrow (EWKB) by the ADBC driver and imported as DuckDB `GEOMETRY`, replacing the prior text passthrough ([#24](https://github.com/iqea-ai/duckdb-snowflake/pull/24), jatorre)
 - Connection pool: each scan leases a dedicated ADBC connection, so concurrent scans (e.g. dbt-duckdb models, self-joins) no longer share one non-thread-safe connection and crash ([#49](https://github.com/iqea-ai/duckdb-snowflake/pull/49), guillesd)
 - CI smoke test that executes the driver installers on Linux, macOS, and Windows ([#47](https://github.com/iqea-ai/duckdb-snowflake/pull/47))
+- CI runs the key-pair test suite: the Snowflake test job now provisions `SNOWFLAKE_PRIVATE_KEY_FILE`, so the ~15 `key_pair` test files execute instead of silently skipping ([#52](https://github.com/iqea-ai/duckdb-snowflake/pull/52))
 
 ### Changed
 - Update DuckDB submodule and CI pins to v1.5.4 ([#46](https://github.com/iqea-ai/duckdb-snowflake/pull/46))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # DuckDB Snowflake Extension
 
-A powerful DuckDB extension that enables seamless querying of Snowflake databases using Arrow ADBC drivers. This extension provides efficient, columnar data transfer between DuckDB and Snowflake, making it ideal for analytics, ETL pipelines, and cross-database operations.
+[![Main Extension Distribution Pipeline](https://github.com/iqea-ai/duckdb-snowflake/actions/workflows/MainDistributionPipeline.yml/badge.svg?branch=main)](https://github.com/iqea-ai/duckdb-snowflake/actions/workflows/MainDistributionPipeline.yml)
+[![Test with Snowflake](https://github.com/iqea-ai/duckdb-snowflake/actions/workflows/test-with-snowflake.yml/badge.svg?branch=main)](https://github.com/iqea-ai/duckdb-snowflake/actions/workflows/test-with-snowflake.yml)
+[![Community Extension](https://img.shields.io/badge/community--extensions-snowflake-blue)](https://github.com/duckdb/community-extensions/blob/main/extensions/snowflake/description.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+A DuckDB extension for querying Snowflake from DuckDB via the Apache Arrow ADBC Snowflake driver. Data flows between the two systems as Arrow record batches, so result sets stay columnar end-to-end.
 
 **This extension works with DuckDB v1.5.4.**
 
@@ -68,15 +73,15 @@ If you want to **install and use** the extension, continue reading this README f
 
 ## Overview
 
-The DuckDB Snowflake Extension bridges the gap between DuckDB's analytical capabilities and Snowflake's cloud data warehouse, allowing you to query Snowflake data directly from DuckDB without complex data movement processes.
+The extension exposes Snowflake to DuckDB as a remote data source. You can either pass SQL straight through to Snowflake with `snowflake_query()`, or `ATTACH` a Snowflake database and query it with DuckDB SQL.
 
-### Key Features
+### Capabilities
 
-- **Direct Querying**: Execute SQL queries against Snowflake from within DuckDB
-- **Arrow-Native Pipeline**: Leverages Apache Arrow for efficient, columnar data transfer
-- **Multiple Authentication Methods**: Support for password, OAuth, key-pair (with passphrase support), external browser SSO, Okta, and MFA authentication
-- **Secret Management**: Secure credential storage using DuckDB's secrets system
-- **Storage Extension**: Attach Snowflake databases as read-only storage
+- Run SQL against Snowflake from DuckDB, either as passthrough (`snowflake_query`) or against an attached Snowflake database
+- Arrow-native transport over the ADBC Snowflake driver
+- Authentication via password, OAuth, key pair (with passphrase), external browser SSO, Okta, and MFA
+- Credentials stored through DuckDB's secrets system
+- Read-only storage extension for `ATTACH`
 
 ## Installation
 
@@ -206,7 +211,7 @@ Test that the driver is found:
 ```sql
 LOAD snowflake;
 SELECT snowflake_version();
--- Should return: "Snowflake Extension v0.1.0"
+-- Should return: "Snowflake Extension v0.5.0"
 ```
 
 ## Configuration
@@ -299,7 +304,7 @@ Returns the extension version information.
 
 ```sql
 SELECT snowflake_version();
--- Returns: "Snowflake Extension v0.1.0"
+-- Returns: "Snowflake Extension v0.5.0"
 ```
 
 ### Table Functions
@@ -346,7 +351,7 @@ SELECT * FROM snow.public.customers LIMIT 10;
 ### Complex Analytics
 
 ```sql
--- Use Snowflake's computational power for complex analytics
+-- Run the analytics on the Snowflake side, then return the result set
 SELECT * FROM snowflake_query(
     '
     WITH monthly_sales AS (


### PR DESCRIPTION
## Summary

#43 is superseded except for two files. #51 landed the version string, CHANGELOG, and template changes; what remained unmerged in #43 was the `BUILD.md` and `README.md` polish (badges, tightened overview/capabilities prose, corrected `snowflake_version()` examples).

- Reapply the `BUILD.md` + `README.md` changes from #43 via 3-way merge onto post-#51 `main`
- Update the version-string examples those hunks carried from #43's stale `v0.4.1` to `v0.5.0` (what `snowflake_version()` actually returns since #51)
- Add the #52 line to the 0.5.0 CHANGELOG entry: CI now provisions `SNOWFLAKE_PRIVATE_KEY_FILE`, so the key-pair test suite runs instead of silently skipping

Docs-only; no source changes. Closes out the #43 line of work — #43 itself will be closed in favor of this PR.