### PR TITLE
Remove emojis from the repository

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -174,7 +174,7 @@ jobs:
           
           # Calculate size in MB (using awk if bc is not available)
           SIZE_MB=$(echo "scale=2; $PACKAGE_SIZE / 1024 / 1024" | bc 2>/dev/null || awk "BEGIN {printf \"%.2f\", $PACKAGE_SIZE / 1024 / 1024}")
-          echo "✓ Package size validation passed: ${SIZE_MB}MB"
+          echo "Package size validation passed: ${SIZE_MB}MB"
           
       - name: Upload complete package
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-with-snowflake.yml
+++ b/.github/workflows/test-with-snowflake.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           # Verify environment variables are set
           if [ -z "$SNOWFLAKE_ACCOUNT" ]; then
-            echo "⚠️  SNOWFLAKE_ACCOUNT secret not set - tests will be skipped"
+            echo "WARNING: SNOWFLAKE_ACCOUNT secret not set - tests will be skipped"
             exit 0
           fi
           

--- a/README.md
+++ b/README.md
@@ -146,12 +146,12 @@ If you prefer to install manually, download and install the appropriate driver f
 
 | Platform | DuckDB Directory | Release Asset | Status |
 |----------|------------------|---------------|--------|
-| **Linux x86_64** | `linux_amd64` | `snowflake_linux_amd64_v1.11.0.tar.gz` | ✅ Supported |
-| **Linux ARM64** | `linux_arm64` | `snowflake_linux_arm64_v1.11.0.tar.gz` | ✅ Supported |
-| **macOS ARM64** | `osx_arm64` | `snowflake_macos_arm64_v1.11.0.tar.gz` | ✅ Supported |
-| **macOS x86_64** | `osx_amd64` | - | ⚠️ Build from source |
-| **Windows x86_64** | `windows_amd64` | `snowflake_windows_amd64_v1.11.0.tar.gz` | ✅ Supported |
-| **Windows ARM64** | - | - | ❌ Not Available |
+| **Linux x86_64** | `linux_amd64` | `snowflake_linux_amd64_v1.11.0.tar.gz` | Supported |
+| **Linux ARM64** | `linux_arm64` | `snowflake_linux_arm64_v1.11.0.tar.gz` | Supported |
+| **macOS ARM64** | `osx_arm64` | `snowflake_macos_arm64_v1.11.0.tar.gz` | Supported |
+| **macOS x86_64** | `osx_amd64` | - | Build from source |
+| **Windows x86_64** | `windows_amd64` | `snowflake_windows_amd64_v1.11.0.tar.gz` | Supported |
+| **Windows ARM64** | - | - | Not available |
 
 > **Note:** The ADBC Driver Foundry ships no macOS x86_64 (Intel) or Windows ARM64 builds. On those platforms, build the driver from [source](https://github.com/adbc-drivers/snowflake) and set `SNOWFLAKE_ADBC_DRIVER_PATH` to the result.
 

--- a/scripts/install-adbc-driver.sh
+++ b/scripts/install-adbc-driver.sh
@@ -28,15 +28,15 @@ print_info() {
 }
 
 print_success() {
-    echo -e "${GREEN}✓${NC} $1"
+    echo -e "${GREEN}OK${NC} $1"
 }
 
 print_error() {
-    echo -e "${RED}✗${NC} $1"
+    echo -e "${RED}ERROR${NC} $1"
 }
 
 print_warning() {
-    echo -e "${YELLOW}⚠${NC} $1"
+    echo -e "${YELLOW}WARN${NC} $1"
 }
 
 # Detect platform

--- a/test/README.md
+++ b/test/README.md
@@ -101,9 +101,9 @@ Tests combine Snowflake and local DuckDB data:
 ### Test Results
 ```
 Running test/sql/snowflake_basic_connectivity.test
-✓ Test 1: Extension Loading
-✓ Test 2: Create Secret
-✓ Test 3: Query Execution
+PASS Test 1: Extension Loading
+PASS Test 2: Create Secret
+PASS Test 3: Query Execution
 All tests passed: 3/3
 ```
 


### PR DESCRIPTION
Removes all emoji and emoji-adjacent glyphs from tracked files: the README platform-support table (Supported / Build from source / Not available as plain text), workflow echo output, install-script status prefixes (OK/ERROR/WARN, colors kept), and the test README sample output. Typographic arrows in the auth docs and the query-builder comment diagram are deliberately kept — they are punctuation, not emoji. Repo policy from here: no emojis anywhere in the repository.