### PR TITLE
Fix #48: project SHOW/DESC results through RESULT_SCAN

### DIFF
--- a/src/include/snowflake_arrow_utils.hpp
+++ b/src/include/snowflake_arrow_utils.hpp
@@ -114,4 +114,12 @@ void SnowflakeGetArrowSchemaViaQuery(SnowflakeArrowStreamFactory *factory, Arrow
 // returned by SnowflakeProduceArrowScan instead of re-executing the query.
 void SnowflakeExecuteAndCacheStream(SnowflakeArrowStreamFactory *factory, ArrowSchema &schema);
 
+// Execute factory->query on the leased connection (discarding its rows) and return
+// Snowflake's query id for it, read via LAST_QUERY_ID() on the same session — the
+// lease guarantees no other statement runs in between. Used by snowflake_query bind
+// to re-target row-returning metadata statements (SHOW/DESC) at
+// TABLE(RESULT_SCAN('<id>')), which unlike the raw statement can be wrapped as a
+// projected subquery (issue #48).
+std::string SnowflakeExecuteAndGetQueryId(SnowflakeArrowStreamFactory *factory);
+
 } // namespace duckdb

--- a/src/snowflake_arrow_utils.cpp
+++ b/src/snowflake_arrow_utils.cpp
@@ -362,6 +362,152 @@ void SnowflakeExecuteAndCacheStream(SnowflakeArrowStreamFactory *factory, ArrowS
 	}
 }
 
+// Execute one statement on the factory's leased connection with a temporary
+// statement handle, optionally keeping the result stream. Shares the
+// auth-error invalidation behavior of the other execution paths.
+// When out_stream is requested, out_statement must be too: an ADBC statement
+// must outlive its active stream (the factory keeps its own statement alive for
+// the same reason), so the caller releases the stream first, then the statement.
+static void ExecuteOnLease(SnowflakeArrowStreamFactory *factory, const std::string &sql, ArrowArrayStream *out_stream,
+                           AdbcStatement *out_statement, const char *what) {
+	AdbcError error;
+	std::memset(&error, 0, sizeof(error));
+	AdbcStatement stmt;
+	std::memset(&stmt, 0, sizeof(stmt));
+	if (AdbcStatementNew(factory->lease->GetConnection(), &stmt, &error) != ADBC_STATUS_OK) {
+		throw IOException(std::string("Failed to create statement for ") + what);
+	}
+	if (AdbcStatementSetSqlQuery(&stmt, sql.c_str(), &error) != ADBC_STATUS_OK) {
+		std::string msg = std::string("Failed to set query for ") + what + ": ";
+		if (error.message) {
+			msg += error.message;
+			if (error.release) {
+				error.release(&error);
+			}
+		}
+		AdbcStatementRelease(&stmt, nullptr);
+		throw IOException(msg);
+	}
+	ArrowArrayStream stream;
+	std::memset(&stream, 0, sizeof(stream));
+	int64_t rows_affected = 0;
+	AdbcError exec_error;
+	std::memset(&exec_error, 0, sizeof(exec_error));
+	if (AdbcStatementExecuteQuery(&stmt, &stream, &rows_affected, &exec_error) != ADBC_STATUS_OK) {
+		std::string msg = std::string("Failed to execute ") + what + ": ";
+		if (exec_error.message) {
+			msg += exec_error.message;
+			if (exec_error.release) {
+				exec_error.release(&exec_error);
+			}
+		}
+		AdbcStatementRelease(&stmt, nullptr);
+		if (IsAuthenticationError(msg)) {
+			auto &client_manager = snowflake::SnowflakeClientManager::GetInstance();
+			// Don't return this connection to the pool, and drop any idle ones —
+			// the auth token has likely expired for all sessions on this config.
+			factory->lease.Invalidate();
+			client_manager.DrainIdle(factory->lease->GetConfig());
+			throw IOException(msg + "\n\nThe authentication token may have expired. "
+			                        "Please retry your query - a fresh connection will be established automatically.");
+		}
+		throw IOException(msg);
+	}
+	if (out_stream) {
+		*out_stream = stream;
+		*out_statement = stmt;
+		return;
+	}
+	if (stream.release) {
+		// Rows are not needed; the statement has run server-side, which is all
+		// RESULT_SCAN requires.
+		stream.release(&stream);
+	}
+	AdbcStatementRelease(&stmt, nullptr);
+}
+
+// Read row 0 of column 0 from a single-batch utf8 stream (e.g. SELECT
+// LAST_QUERY_ID()). Handles both 32-bit ("u") and 64-bit ("U") offset layouts.
+static std::string ReadFirstRowUtf8(ArrowArrayStream &stream, const char *what) {
+	ArrowSchema schema;
+	std::memset(&schema, 0, sizeof(schema));
+	if (!stream.get_schema || stream.get_schema(&stream, &schema) != 0) {
+		throw IOException(std::string("Failed to read schema from ") + what);
+	}
+	std::string format;
+	if (schema.n_children == 1 && schema.children[0] && schema.children[0]->format) {
+		format = schema.children[0]->format;
+	}
+	if (schema.release) {
+		schema.release(&schema);
+	}
+	if (format != "u" && format != "U") {
+		throw IOException(std::string(what) + " returned unexpected Arrow type '" + format + "', expected utf8");
+	}
+
+	ArrowArray batch;
+	std::memset(&batch, 0, sizeof(batch));
+	if (!stream.get_next || stream.get_next(&stream, &batch) != 0 || !batch.release) {
+		throw IOException(std::string("Failed to read result batch from ") + what);
+	}
+	std::string value;
+	auto *col = batch.children && batch.n_children == 1 ? batch.children[0] : nullptr;
+	if (!col || col->length < 1 || col->n_buffers < 3) {
+		batch.release(&batch);
+		throw IOException(std::string(what) + " returned no rows");
+	}
+	auto row = col->offset;
+	auto data = reinterpret_cast<const char *>(col->buffers[2]);
+	if (format == "u") {
+		auto offsets = reinterpret_cast<const int32_t *>(col->buffers[1]);
+		value.assign(data + offsets[row], offsets[row + 1] - offsets[row]);
+	} else {
+		auto offsets = reinterpret_cast<const int64_t *>(col->buffers[1]);
+		value.assign(data + offsets[row], offsets[row + 1] - offsets[row]);
+	}
+	batch.release(&batch);
+	return value;
+}
+
+std::string SnowflakeExecuteAndGetQueryId(SnowflakeArrowStreamFactory *factory) {
+	// Run the statement itself; RESULT_SCAN only needs it executed server-side.
+	ExecuteOnLease(factory, factory->query, nullptr, nullptr, "metadata statement");
+
+	// Same session (exclusive lease), so LAST_QUERY_ID() is the statement above.
+	// The statement handle stays open until the stream is drained and released.
+	ArrowArrayStream id_stream;
+	std::memset(&id_stream, 0, sizeof(id_stream));
+	AdbcStatement id_stmt;
+	std::memset(&id_stmt, 0, sizeof(id_stmt));
+	ExecuteOnLease(factory, "SELECT LAST_QUERY_ID()", &id_stream, &id_stmt, "LAST_QUERY_ID()");
+	std::string query_id;
+	try {
+		query_id = ReadFirstRowUtf8(id_stream, "LAST_QUERY_ID()");
+	} catch (...) {
+		if (id_stream.release) {
+			id_stream.release(&id_stream);
+		}
+		AdbcStatementRelease(&id_stmt, nullptr);
+		throw;
+	}
+	if (id_stream.release) {
+		id_stream.release(&id_stream);
+	}
+	AdbcStatementRelease(&id_stmt, nullptr);
+
+	// The id feeds a quoted SQL literal; Snowflake ids are UUID-shaped, so anything
+	// else means we mis-read the result and must not splice it into a query.
+	for (auto c : query_id) {
+		if (!isalnum(static_cast<unsigned char>(c)) && c != '-') {
+			throw IOException("Unexpected query id from LAST_QUERY_ID(): " + query_id);
+		}
+	}
+	if (query_id.empty()) {
+		throw IOException("LAST_QUERY_ID() returned an empty id");
+	}
+	return query_id;
+}
+
 void SnowflakeArrowStreamFactory::UpdatePushdownParameters(const vector<string> &projection,
                                                            TableFilterSet *filter_set) {
 	DPRINT("UpdatePushdownParameters called: projection_size=%lu, "

--- a/src/snowflake_scan.cpp
+++ b/src/snowflake_scan.cpp
@@ -65,6 +65,8 @@ static unique_ptr<FunctionData> SnowflakeScanBind(ClientContext &context, TableF
 	auto upper = StringUtil::Upper(trimmed);
 	bool is_select = StringUtil::StartsWith(upper, "SELECT") || StringUtil::StartsWith(upper, "WITH") ||
 	                 StringUtil::StartsWith(upper, "(");
+	// Row-returning metadata statements. DESC also covers DESCRIBE.
+	bool is_metadata_rows = StringUtil::StartsWith(upper, "SHOW") || StringUtil::StartsWith(upper, "DESC");
 
 	if (is_select) {
 		// SELECT path: DuckDB's Arrow scanner prunes columns and reads the produced
@@ -73,6 +75,23 @@ static unique_ptr<FunctionData> SnowflakeScanBind(ClientContext &context, TableF
 		// So enable projection pushdown and let SnowflakeProduceArrowScan wrap the
 		// query as a projected subquery. Fetch the schema cheaply with LIMIT 0
 		// (data-path schema) rather than caching the full result.
+		bind_data->factory->projection_pushdown_enabled = true;
+		bind_data->factory->wrap_as_subquery = true;
+		bind_data->projection_pushdown_enabled = true;
+		SnowflakeGetArrowSchemaViaQuery(bind_data->factory.get(), bind_data->schema_root.arrow_schema);
+	} else if (is_metadata_rows) {
+		// SHOW/DESC return rows but cannot be wrapped as a subquery, so the SELECT
+		// path's projection wrap can't apply to the raw statement — and the cached
+		// full-width stream misaligns DuckDB's positional reads on non-prefix
+		// projections (issue #48; prefix projections only worked by accident).
+		// Instead: execute the statement now, then re-target the scan at
+		// TABLE(RESULT_SCAN('<query id>')), which IS wrappable, and rejoin the
+		// SELECT path machinery. The factory's exclusive lease guarantees
+		// LAST_QUERY_ID() sees our statement.
+		auto query_id = SnowflakeExecuteAndGetQueryId(bind_data->factory.get());
+		auto result_scan_query = "SELECT * FROM TABLE(RESULT_SCAN('" + query_id + "'))";
+		bind_data->factory->query = result_scan_query;
+		bind_data->factory->modified_query = result_scan_query;
 		bind_data->factory->projection_pushdown_enabled = true;
 		bind_data->factory->wrap_as_subquery = true;
 		bind_data->projection_pushdown_enabled = true;

--- a/test/sql/snowflake_show_projection.test
+++ b/test/sql/snowflake_show_projection.test
@@ -1,0 +1,80 @@
+# name: test/sql/snowflake_show_projection.test
+# description: Regression test for issue #48 - projected SHOW/DESC through snowflake_query()
+# group: [sql]
+
+#              SHOW/DESC cannot be wrapped as a subquery, so the bind re-targets the scan at
+#              TABLE(RESULT_SCAN('<query id>')) and reuses the projected-subquery machinery
+#              from the SELECT path. Before the fix, non-prefix projections misaligned
+#              DuckDB's positional Arrow reads: type mismatches (ArrowTypeInfo INTERNAL
+#              Error) or silently swapped values; prefix projections worked by accident.
+
+require snowflake
+
+require-env SNOWFLAKE_ACCOUNT
+
+require-env SNOWFLAKE_KEYPAIR_USER
+
+require-env SNOWFLAKE_PRIVATE_KEY_PATH
+
+require-env SNOWFLAKE_PRIVATE_KEY_PASSPHRASE
+
+require-env SNOWFLAKE_DATABASE
+
+statement ok
+LOAD snowflake;
+
+statement ok
+CREATE SECRET sf_show_secret (
+    TYPE snowflake,
+    ACCOUNT '${SNOWFLAKE_ACCOUNT}',
+    USER '${SNOWFLAKE_KEYPAIR_USER}',
+    AUTH_TYPE 'key_pair',
+    PRIVATE_KEY_FILE '${SNOWFLAKE_PRIVATE_KEY_PATH}',
+    PRIVATE_KEY_PASSWORD '${SNOWFLAKE_PRIVATE_KEY_PASSPHRASE}',
+    DATABASE '${SNOWFLAKE_DATABASE}',
+    WAREHOUSE 'COMPUTE_WH'
+);
+
+# Test 1: SELECT * over SHOW (baseline - always worked)
+query I
+SELECT count(*) >= 1 FROM snowflake_query('SHOW DATABASES', 'sf_show_secret');
+----
+true
+
+# Test 2: non-prefix projection over SHOW DATABASES (the #48 crash).
+# created_on (timestamp) is column 0, so projecting name/kind read a DATE_TIME
+# where a STRING was expected before the fix.
+query II
+SELECT "name", "kind" FROM snowflake_query('SHOW DATABASES LIKE ''SNOWFLAKE''', 'sf_show_secret');
+----
+SNOWFLAKE	APPLICATION
+
+# Test 3: reversed projection returns values in the requested order, not
+# positionally swapped (the silent-wrong-data variant of #48)
+query II
+SELECT "kind", "name" FROM snowflake_query('SHOW DATABASES LIKE ''SNOWFLAKE''', 'sf_show_secret');
+----
+APPLICATION	SNOWFLAKE
+
+# Test 4: single non-first column over DESC TABLE
+query I
+SELECT "type" FROM snowflake_query('DESC TABLE ${SNOWFLAKE_DATABASE}.TPCH_SF1.CUSTOMER', 'sf_show_secret') LIMIT 1;
+----
+NUMBER(38,0)
+
+# Test 5: DESCRIBE spelled out routes the same way
+query I
+SELECT "name" FROM snowflake_query('DESCRIBE TABLE ${SNOWFLAKE_DATABASE}.TPCH_SF1.CUSTOMER', 'sf_show_secret') LIMIT 2;
+----
+C_CUSTKEY
+C_NAME
+
+# Test 6: aggregation over SHOW (empty projection - all columns pruned)
+query I
+SELECT count(*) FROM snowflake_query('SHOW DATABASES LIKE ''SNOWFLAKE''', 'sf_show_secret');
+----
+1
+
+# Cleanup
+statement ok
+DROP SECRET IF EXISTS sf_show_secret;


### PR DESCRIPTION
## Problem

`snowflake_query` declares function-level `projection_pushdown`, so DuckDB reads every produced Arrow stream positionally (child[k] = k-th requested column). The SELECT path honors that by rewriting the SQL as a projected subquery (#32), but SHOW/DESC returned the cached full-width stream — a non-prefix projection read the wrong child: `Failed to cast ArrowTypeInfo, type mismatch`, or silently swapped values when types coincided. Prefix projections only worked by accident.

## Fix

SHOW/DESC can't be wrapped as a subquery, so bind now executes the statement, reads `LAST_QUERY_ID()` on the same leased connection (the exclusive `ConnectionLease` guarantees nothing interleaves — same property that makes #49's pool safe), and re-targets the scan at `SELECT * FROM TABLE(RESULT_SCAN('<id>'))` — which IS wrappable, so the existing passthrough projection machinery applies and the stream matches the projection by construction. DDL/DML status statements keep the cached-stream path unchanged. The query id is validated as UUID-shaped before being spliced into SQL.

Cost: a SHOW scan is three cheap statements instead of one; in exchange the result is re-readable (the old cached stream was one-shot).

## Verification

- New `test/sql/snowflake_show_projection.test`: the crash case, the reversed-projection silent-swap case, DESC/DESCRIBE routing, empty projection.
- Live end-to-end before/after: the exact repro from #48 fails on main with the ArrowTypeInfo error and returns correct rows on this branch; `snowflake_query_projection` and `snowflake_query_ddl` stay green.
- clang-tidy clean on changed files (repo config, warnings-as-errors).

Closes #48.