### PR TITLE
Fix #50: discover the ADBC driver via standardized driver manifests

### DIFF
--- a/.github/workflows/test-with-snowflake.yml
+++ b/.github/workflows/test-with-snowflake.yml
@@ -126,7 +126,17 @@ jobs:
           ./build/release/test/unittest "*snowflake_*"
           echo "Running test/sql/pushdown/*.test files..."
           ./build/release/test/unittest "[pushdown]"
-      
+
+      # Guard the dbc/manifest install path (issue #50). Every other job finds
+      # the driver sitting next to the binary, so this is the only coverage
+      # manifest discovery has; without it a regression ships silently. The
+      # script skips itself when secrets are absent, keeping forks green.
+      - name: Manifest-discovery smoke test
+        env:
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_DATABASE: ${{ secrets.SNOWFLAKE_DATABASE }}
+        run: bash scripts/manifest_smoke_test.sh
+
       - name: Remove private key
         if: always()
         run: rm -f "$RUNNER_TEMP/sf_key.p8"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(EXTENSION_SOURCES
     src/snowflake_client.cpp
     src/snowflake_client_manager.cpp
     src/snowflake_config.cpp
+    src/snowflake_driver_manifest.cpp
     src/snowflake_types.cpp
     src/snowflake_transaction.cpp
     src/storage/snowflake_storage.cpp

--- a/README.md
+++ b/README.md
@@ -133,10 +133,9 @@ The installer will:
 
 ```bash
 dbc install snowflake
-export SNOWFLAKE_ADBC_DRIVER_PATH="<path dbc installed the driver to>"
 ```
 
-The extension resolves the driver by explicit path, not driver-manager manifest discovery, so point `SNOWFLAKE_ADBC_DRIVER_PATH` at the installed library.
+That is all: the extension discovers dbc-installed drivers through the standard ADBC driver manifests — `snowflake.toml` in the `ADBC_DRIVER_PATH` directories, the active conda prefix, and the per-OS manifest directories on Linux and macOS; the `SOFTWARE\ADBC\Drivers\snowflake` registry keys on Windows. No environment variable is needed. `SNOWFLAKE_ADBC_DRIVER_PATH` still works as an explicit override and takes precedence over manifest discovery.
 
 ### Manual Installation (advanced)
 

--- a/scripts/manifest_smoke_test.sh
+++ b/scripts/manifest_smoke_test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Smoke test for ADBC driver-manifest discovery (issue #50), run by
+# test-with-snowflake.yml and runnable locally on macOS.
+#
+# Proves the driver resolves through a snowflake.toml manifest ALONE: the
+# duckdb binary is copied to a directory with no driver beside it (the
+# extension-directory probe resolves to the binary's dir for the statically
+# linked shell) and no SNOWFLAKE_ADBC_DRIVER_PATH is set. A negative control
+# runs first: with no manifest either, resolution must FAIL - otherwise the
+# test bed is leaking a driver source and the positive result means nothing.
+# Every other CI job finds the driver by adjacency, so without this leg a
+# manifest-discovery regression would ship silently.
+set -euo pipefail
+
+DUCKDB_BIN="${DUCKDB_BIN:-build/release/duckdb}"
+DRIVER="${DRIVER:-$PWD/adbc_drivers/libadbc_driver_snowflake.so}"
+
+for v in SNOWFLAKE_ACCOUNT SNOWFLAKE_KEYPAIR_USER SNOWFLAKE_PRIVATE_KEY_FILE SNOWFLAKE_DATABASE; do
+    if [ -z "${!v:-}" ]; then
+        echo "$v not set - skipping manifest smoke test."
+        exit 0
+    fi
+done
+[ -f "$DRIVER" ] || { echo "FAIL: driver not found at $DRIVER"; exit 1; }
+
+MDIR="$HOME/Library/Application Support/ADBC/Drivers"
+MANIFEST="$MDIR/snowflake.toml"
+if [ -f "$MANIFEST" ]; then
+    echo "FAIL: pre-existing manifest at $MANIFEST - refusing to clobber it"
+    exit 1
+fi
+
+WORK=$(mktemp -d)
+CREATED_MANIFEST=0
+cleanup() {
+    [ "$CREATED_MANIFEST" = 1 ] && rm -f "$MANIFEST"
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+cp "$DUCKDB_BIN" "$WORK/duckdb"
+# No escape hatches: resolution may only come from the manifest under test.
+unset SNOWFLAKE_ADBC_DRIVER_PATH CONDA_PREFIX ADBC_DRIVER_PATH
+
+SQL="CREATE SECRET sf_smoke (TYPE snowflake, ACCOUNT '$SNOWFLAKE_ACCOUNT',
+    USER '$SNOWFLAKE_KEYPAIR_USER', AUTH_TYPE 'key_pair',
+    PRIVATE_KEY_FILE '$SNOWFLAKE_PRIVATE_KEY_FILE',
+    PRIVATE_KEY_PASSWORD '${SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE:-}',
+    DATABASE '$SNOWFLAKE_DATABASE', WAREHOUSE 'COMPUTE_WH');
+SELECT * FROM snowflake_query('SELECT 42 AS answer', 'sf_smoke');"
+
+echo "== negative control: no manifest -> driver must NOT be found"
+if OUT=$("$WORK/duckdb" -unsigned -noheader -list -c "$SQL" 2>&1); then
+    echo "FAIL: query succeeded with no driver source at all"
+    echo "$OUT" | tail -5
+    exit 1
+fi
+if ! echo "$OUT" | grep -q "not found"; then
+    echo "FAIL: expected a driver-not-found error, got:"
+    echo "$OUT" | tail -5
+    exit 1
+fi
+echo "ok: driver correctly not found without a manifest"
+
+echo "== manifest present -> driver must resolve through it and answer a query"
+mkdir -p "$MDIR"
+printf "[Driver]\n[Driver.shared]\nmacos_arm64 = '%s'\nmacos_amd64 = '%s'\n" \
+    "$DRIVER" "$DRIVER" > "$MANIFEST"
+CREATED_MANIFEST=1
+if ! OUT=$("$WORK/duckdb" -unsigned -noheader -list -c "$SQL" 2>&1); then
+    echo "FAIL: query failed with manifest present:"
+    echo "$OUT" | tail -5
+    exit 1
+fi
+if ! echo "$OUT" | grep -q '^42$'; then
+    echo "FAIL: expected query answer 42, got:"
+    echo "$OUT" | tail -5
+    exit 1
+fi
+echo "ok: query answered through the manifest-resolved driver"

--- a/src/include/snowflake_driver_manifest.hpp
+++ b/src/include/snowflake_driver_manifest.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace duckdb {
+namespace snowflake {
+
+// Directories searched for ADBC driver manifests (snowflake.toml), in priority
+// order: ADBC_DRIVER_PATH entries (colon-separated, semicolon on Windows), the
+// active conda prefix (dbc installs there when a conda env is active), the
+// per-user config dir, then the system dir. Windows registry locations
+// (HKEY_*\SOFTWARE\ADBC\Drivers) are a follow-up — see issue #50.
+std::vector<std::string> GetAdbcManifestDirs();
+
+// Read <dir>/snowflake.toml and return the shared-library path it names for the
+// current platform, or "" when the manifest is absent or names none. Targeted
+// TOML read, not a full parser: handles `shared = '<path>'` under [Driver] and
+// platform-keyed entries under [Driver.shared] (dbc writes e.g. macos_arm64;
+// DuckDB-style osx_* keys are accepted as aliases), single- or double-quoted.
+// Best-effort by design: a malformed manifest yields "" and the caller falls
+// through to the next search location, never a hard failure.
+std::string ResolveDriverFromManifestDir(const std::string &dir);
+
+} // namespace snowflake
+} // namespace duckdb

--- a/src/include/snowflake_driver_manifest.hpp
+++ b/src/include/snowflake_driver_manifest.hpp
@@ -6,11 +6,18 @@
 namespace duckdb {
 namespace snowflake {
 
-// Directories searched for ADBC driver manifests (snowflake.toml), in priority
-// order: ADBC_DRIVER_PATH entries (colon-separated, semicolon on Windows), the
-// active conda prefix (dbc installs there when a conda env is active), the
-// per-user config dir, then the system dir. Windows registry locations
-// (HKEY_*\SOFTWARE\ADBC\Drivers) are a follow-up — see issue #50.
+// Directories searched for ADBC driver manifests (snowflake.toml), split to
+// preserve the spec's search order around the Windows registry (which sits
+// between the environment-driven dirs and the per-OS dirs, see
+// ResolveDriverFromRegistry):
+//   env dirs      - ADBC_DRIVER_PATH entries (colon-separated, semicolon on
+//                   Windows) and the active conda prefix (dbc installs there
+//                   when a conda env is active)
+//   platform dirs - the per-user config dir, then the system dir
+std::vector<std::string> GetAdbcManifestEnvDirs();
+std::vector<std::string> GetAdbcManifestPlatformDirs();
+
+// Both lists concatenated in search order; used for error reporting.
 std::vector<std::string> GetAdbcManifestDirs();
 
 // Read <dir>/snowflake.toml and return the shared-library path it names for the
@@ -21,6 +28,15 @@ std::vector<std::string> GetAdbcManifestDirs();
 // Best-effort by design: a malformed manifest yields "" and the caller falls
 // through to the next search location, never a hard failure.
 std::string ResolveDriverFromManifestDir(const std::string &dir);
+
+// Windows registry manifests: HKEY_CURRENT_USER (user level) or
+// HKEY_LOCAL_MACHINE (system level) SOFTWARE\ADBC\Drivers\snowflake, value
+// "driver" = path to the shared library. This is how `dbc install snowflake`
+// registers the driver on Windows — it writes no .toml there at all — and per
+// the ADBC manifest spec the user-level registry key is consulted before the
+// %LOCALAPPDATA% manifest dir, the system-level key after it. Returns "" when
+// the key is absent, on error, and always on non-Windows platforms.
+std::string ResolveDriverFromRegistry(bool system_level);
 
 } // namespace snowflake
 } // namespace duckdb

--- a/src/snowflake_client.cpp
+++ b/src/snowflake_client.cpp
@@ -1,5 +1,6 @@
 #include "snowflake_debug.hpp"
 #include "snowflake_client.hpp"
+#include "snowflake_driver_manifest.hpp"
 #include "snowflake_types.hpp"
 #include "snowflake_query_builder.hpp"
 
@@ -143,7 +144,18 @@ void SnowflakeClient::InitializeDatabase(const SnowflakeConfig &config) {
 		search_paths.push_back(env_path);
 	}
 
-	// 3. Try system paths
+	// 3. ADBC driver-manifest discovery (issue #50): snowflake.toml in the dirs
+	// from ADBC_DRIVER_PATH, the active conda prefix, and the standardized
+	// per-OS manifest locations. This is what makes `dbc install snowflake`
+	// work with no env var.
+	for (const auto &manifest_dir : GetAdbcManifestDirs()) {
+		auto manifest_driver = ResolveDriverFromManifestDir(manifest_dir);
+		if (!manifest_driver.empty()) {
+			search_paths.push_back(manifest_driver);
+		}
+	}
+
+	// 4. Try system paths
 #ifdef _WIN32
 	search_paths.push_back(std::string("C:\\Windows\\System32\\") + SNOWFLAKE_ADBC_LIB);
 	search_paths.push_back(std::string("C:\\Program Files\\Snowflake\\") + SNOWFLAKE_ADBC_LIB);
@@ -152,7 +164,7 @@ void SnowflakeClient::InitializeDatabase(const SnowflakeConfig &config) {
 	search_paths.push_back(std::string("/usr/lib/") + SNOWFLAKE_ADBC_LIB);
 #endif
 
-	// 4. Try just the filename - let the system search for it
+	// 5. Try just the filename - let the system search for it
 	search_paths.emplace_back(SNOWFLAKE_ADBC_LIB);
 
 	// Find the first existing driver
@@ -173,6 +185,11 @@ void SnowflakeClient::InitializeDatabase(const SnowflakeConfig &config) {
 		for (const auto &path : search_paths) {
 			error_msg += "  - " + path + "\n";
 		}
+		error_msg += "Also searched for driver manifests (snowflake.toml) in:\n";
+		for (const auto &manifest_dir : GetAdbcManifestDirs()) {
+			error_msg += "  - " + manifest_dir + "\n";
+		}
+		error_msg += "Install the driver with scripts/install-adbc-driver.sh or `dbc install snowflake`.";
 
 		throw IOException(error_msg);
 	}

--- a/src/snowflake_client.cpp
+++ b/src/snowflake_client.cpp
@@ -145,14 +145,30 @@ void SnowflakeClient::InitializeDatabase(const SnowflakeConfig &config) {
 	}
 
 	// 3. ADBC driver-manifest discovery (issue #50): snowflake.toml in the dirs
-	// from ADBC_DRIVER_PATH, the active conda prefix, and the standardized
-	// per-OS manifest locations. This is what makes `dbc install snowflake`
-	// work with no env var.
-	for (const auto &manifest_dir : GetAdbcManifestDirs()) {
+	// from ADBC_DRIVER_PATH and the active conda prefix, then the Windows
+	// registry manifests interleaved with the per-OS manifest dirs in the
+	// spec's order (user registry, user/system dirs, machine registry). On
+	// Windows the registry is what `dbc install snowflake` actually writes —
+	// no .toml — so this is what makes it work with no env var.
+	for (const auto &manifest_dir : GetAdbcManifestEnvDirs()) {
 		auto manifest_driver = ResolveDriverFromManifestDir(manifest_dir);
 		if (!manifest_driver.empty()) {
 			search_paths.push_back(manifest_driver);
 		}
+	}
+	auto user_registry_driver = ResolveDriverFromRegistry(/*system_level=*/false);
+	if (!user_registry_driver.empty()) {
+		search_paths.push_back(user_registry_driver);
+	}
+	for (const auto &manifest_dir : GetAdbcManifestPlatformDirs()) {
+		auto manifest_driver = ResolveDriverFromManifestDir(manifest_dir);
+		if (!manifest_driver.empty()) {
+			search_paths.push_back(manifest_driver);
+		}
+	}
+	auto system_registry_driver = ResolveDriverFromRegistry(/*system_level=*/true);
+	if (!system_registry_driver.empty()) {
+		search_paths.push_back(system_registry_driver);
 	}
 
 	// 4. Try system paths
@@ -189,6 +205,9 @@ void SnowflakeClient::InitializeDatabase(const SnowflakeConfig &config) {
 		for (const auto &manifest_dir : GetAdbcManifestDirs()) {
 			error_msg += "  - " + manifest_dir + "\n";
 		}
+#ifdef _WIN32
+		error_msg += "And registry manifests at HKCU and HKLM SOFTWARE\\ADBC\\Drivers\\snowflake.\n";
+#endif
 		error_msg += "Install the driver with scripts/install-adbc-driver.sh or `dbc install snowflake`.";
 
 		throw IOException(error_msg);

--- a/src/snowflake_driver_manifest.cpp
+++ b/src/snowflake_driver_manifest.cpp
@@ -4,6 +4,16 @@
 #include <cstdlib>
 #include <fstream>
 
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#endif
+
 namespace duckdb {
 namespace snowflake {
 
@@ -56,7 +66,7 @@ static std::string ExtractTomlString(const std::string &raw) {
 	return value;
 }
 
-std::vector<std::string> GetAdbcManifestDirs() {
+std::vector<std::string> GetAdbcManifestEnvDirs() {
 	std::vector<std::string> dirs;
 
 	// 1. Explicit override: a list of manifest directories.
@@ -87,9 +97,13 @@ std::vector<std::string> GetAdbcManifestDirs() {
 			dirs.push_back(std::string(conda) + "/etc/adbc/drivers");
 		}
 	}
+	return dirs;
+}
 
-	// 3. Per-user config dir, then 4. system dir.
-	const char *home = std::getenv("HOME");
+std::vector<std::string> GetAdbcManifestPlatformDirs() {
+	std::vector<std::string> dirs;
+
+	// Per-user config dir, then system dir.
 #if defined(_WIN32)
 	if (const char *localappdata = std::getenv("LOCALAPPDATA")) {
 		if (*localappdata) {
@@ -97,11 +111,13 @@ std::vector<std::string> GetAdbcManifestDirs() {
 		}
 	}
 #elif defined(__APPLE__)
+	const char *home = std::getenv("HOME");
 	if (home && *home) {
 		dirs.push_back(std::string(home) + "/Library/Application Support/ADBC/Drivers");
 	}
 	dirs.emplace_back("/Library/Application Support/ADBC/Drivers");
 #else
+	const char *home = std::getenv("HOME");
 	const char *xdg = std::getenv("XDG_CONFIG_HOME");
 	if (xdg && *xdg) {
 		dirs.push_back(std::string(xdg) + "/adbc/drivers");
@@ -112,6 +128,44 @@ std::vector<std::string> GetAdbcManifestDirs() {
 #endif
 	return dirs;
 }
+
+std::vector<std::string> GetAdbcManifestDirs() {
+	auto dirs = GetAdbcManifestEnvDirs();
+	auto platform_dirs = GetAdbcManifestPlatformDirs();
+	dirs.insert(dirs.end(), platform_dirs.begin(), platform_dirs.end());
+	return dirs;
+}
+
+#if defined(_WIN32)
+std::string ResolveDriverFromRegistry(bool system_level) {
+	HKEY root = system_level ? HKEY_LOCAL_MACHINE : HKEY_CURRENT_USER;
+	HKEY key = nullptr;
+	if (RegOpenKeyExA(root, "SOFTWARE\\ADBC\\Drivers\\snowflake", 0, KEY_QUERY_VALUE, &key) != ERROR_SUCCESS) {
+		return "";
+	}
+	// Two-call pattern: size first, then value. RRF_RT_REG_SZ rejects other
+	// value types and guarantees null termination.
+	DWORD size = 0;
+	std::string value;
+	if (RegGetValueA(key, nullptr, "driver", RRF_RT_REG_SZ, nullptr, nullptr, &size) == ERROR_SUCCESS && size > 0) {
+		std::vector<char> buf(size);
+		if (RegGetValueA(key, nullptr, "driver", RRF_RT_REG_SZ, nullptr, buf.data(), &size) == ERROR_SUCCESS) {
+			value.assign(buf.data()); // stops at the terminator
+		}
+	}
+	RegCloseKey(key);
+	if (!value.empty()) {
+		DPRINT("Registry manifest %s\\SOFTWARE\\ADBC\\Drivers\\snowflake resolves to: %s\n",
+		       system_level ? "HKLM" : "HKCU", value.c_str());
+	}
+	return value;
+}
+#else
+std::string ResolveDriverFromRegistry(bool system_level) {
+	(void)system_level;
+	return "";
+}
+#endif
 
 std::string ResolveDriverFromManifestDir(const std::string &dir) {
 	std::ifstream manifest(dir + "/snowflake.toml");

--- a/src/snowflake_driver_manifest.cpp
+++ b/src/snowflake_driver_manifest.cpp
@@ -1,0 +1,162 @@
+#include "snowflake_driver_manifest.hpp"
+#include "snowflake_debug.hpp"
+
+#include <cstdlib>
+#include <fstream>
+
+namespace duckdb {
+namespace snowflake {
+
+// Platform tuple as spelled in ADBC driver manifests (dbc writes macos_arm64,
+// linux_amd64, ...). DuckDB's own osx_* spelling is accepted as an alias.
+#if defined(_WIN32)
+static const char *const MANIFEST_OS = "windows";
+static const char *const MANIFEST_OS_ALIAS = "windows";
+#elif defined(__APPLE__)
+static const char *const MANIFEST_OS = "macos";
+static const char *const MANIFEST_OS_ALIAS = "osx";
+#else
+static const char *const MANIFEST_OS = "linux";
+static const char *const MANIFEST_OS_ALIAS = "linux";
+#endif
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+static const char *const MANIFEST_ARCH = "arm64";
+#else
+static const char *const MANIFEST_ARCH = "amd64";
+#endif
+
+static std::string TrimWs(const std::string &s) {
+	auto begin = s.find_first_not_of(" \t\r\n");
+	if (begin == std::string::npos) {
+		return "";
+	}
+	auto end = s.find_last_not_of(" \t\r\n");
+	return s.substr(begin, end - begin + 1);
+}
+
+// Extract a TOML string value: quoted (single or double, possibly followed by a
+// comment) or bare-until-comment. Returns "" for anything else.
+static std::string ExtractTomlString(const std::string &raw) {
+	auto value = TrimWs(raw);
+	if (value.empty()) {
+		return "";
+	}
+	if (value[0] == '\'' || value[0] == '"') {
+		auto close = value.find(value[0], 1);
+		if (close == std::string::npos) {
+			return "";
+		}
+		return value.substr(1, close - 1);
+	}
+	auto hash = value.find('#');
+	if (hash != std::string::npos) {
+		value = TrimWs(value.substr(0, hash));
+	}
+	return value;
+}
+
+std::vector<std::string> GetAdbcManifestDirs() {
+	std::vector<std::string> dirs;
+
+	// 1. Explicit override: a list of manifest directories.
+	if (const char *adbc_path = std::getenv("ADBC_DRIVER_PATH")) {
+#if defined(_WIN32)
+		const char sep = ';';
+#else
+		const char sep = ':';
+#endif
+		std::string paths(adbc_path);
+		size_t start = 0;
+		while (start <= paths.size()) {
+			auto end = paths.find(sep, start);
+			auto part = paths.substr(start, end == std::string::npos ? std::string::npos : end - start);
+			if (!TrimWs(part).empty()) {
+				dirs.push_back(TrimWs(part));
+			}
+			if (end == std::string::npos) {
+				break;
+			}
+			start = end + 1;
+		}
+	}
+
+	// 2. Active conda environment: dbc installs here when a conda env is active.
+	if (const char *conda = std::getenv("CONDA_PREFIX")) {
+		if (*conda) {
+			dirs.push_back(std::string(conda) + "/etc/adbc/drivers");
+		}
+	}
+
+	// 3. Per-user config dir, then 4. system dir.
+	const char *home = std::getenv("HOME");
+#if defined(_WIN32)
+	if (const char *localappdata = std::getenv("LOCALAPPDATA")) {
+		if (*localappdata) {
+			dirs.push_back(std::string(localappdata) + "\\ADBC\\Drivers");
+		}
+	}
+#elif defined(__APPLE__)
+	if (home && *home) {
+		dirs.push_back(std::string(home) + "/Library/Application Support/ADBC/Drivers");
+	}
+	dirs.emplace_back("/Library/Application Support/ADBC/Drivers");
+#else
+	const char *xdg = std::getenv("XDG_CONFIG_HOME");
+	if (xdg && *xdg) {
+		dirs.push_back(std::string(xdg) + "/adbc/drivers");
+	} else if (home && *home) {
+		dirs.push_back(std::string(home) + "/.config/adbc/drivers");
+	}
+	dirs.emplace_back("/etc/adbc/drivers");
+#endif
+	return dirs;
+}
+
+std::string ResolveDriverFromManifestDir(const std::string &dir) {
+	std::ifstream manifest(dir + "/snowflake.toml");
+	if (!manifest.is_open()) {
+		return "";
+	}
+
+	const std::string platform_key = std::string(MANIFEST_OS) + "_" + MANIFEST_ARCH;
+	const std::string platform_alias = std::string(MANIFEST_OS_ALIAS) + "_" + MANIFEST_ARCH;
+	std::string plain_shared;    // [Driver] shared = '<path>'
+	std::string platform_shared; // [Driver.shared] <platform> = '<path>'
+	std::string section;
+	std::string line;
+	while (std::getline(manifest, line)) {
+		auto trimmed = TrimWs(line);
+		if (trimmed.empty() || trimmed[0] == '#') {
+			continue;
+		}
+		if (trimmed[0] == '[') {
+			auto close = trimmed.find(']');
+			section = close == std::string::npos ? "" : trimmed.substr(1, close - 1);
+			continue;
+		}
+		auto eq = trimmed.find('=');
+		if (eq == std::string::npos) {
+			continue;
+		}
+		auto key = TrimWs(trimmed.substr(0, eq));
+		auto value = ExtractTomlString(trimmed.substr(eq + 1));
+		if (value.empty()) {
+			continue;
+		}
+		if (section == "Driver" && key == "shared") {
+			plain_shared = value;
+		} else if (section == "Driver.shared" && (key == platform_key || key == platform_alias)) {
+			platform_shared = value;
+		}
+	}
+
+	auto resolved = !platform_shared.empty() ? platform_shared : plain_shared;
+	if (!resolved.empty()) {
+		DPRINT("Driver manifest %s/snowflake.toml resolves to: %s\n", dir.c_str(), resolved.c_str());
+	}
+	return resolved;
+}
+
+} // namespace snowflake
+} // namespace duckdb


### PR DESCRIPTION
## Problem

The driver search list knew the extension directory, `SNOWFLAKE_ADBC_DRIVER_PATH`, and two hardcoded system paths. Manifest-based installs (`dbc install snowflake`) register the driver where the ADBC ecosystem says drivers live — a `snowflake.toml` naming the shared-library path — so the driver existed on disk but the extension couldn't find it without a hand-exported env var.

## Fix

Manifest discovery between the env var and the system paths, grounded on the manifest dbc actually writes (not just the spec): `snowflake.toml` is looked up in `ADBC_DRIVER_PATH` entries, the active conda prefix (where dbc installs when a conda env is active), the per-user config dir, and the system dir. `Driver.shared` is read as a plain string or a platform-keyed table (`macos_arm64` style; `osx_*` accepted as alias). Targeted TOML read, best-effort by design: a malformed manifest falls through to the next location and can never break an existing setup. The driver-not-found error now lists the manifest dirs searched plus both install commands. Windows registry locations are a documented follow-up.

This is what makes `dbc install snowflake` zero-config and lets the community-extensions page present dbc as the primary install path.

## CI guard (second commit)

Every other CI job finds the driver sitting next to the binary, so manifest discovery had zero CI coverage — a regression would ship silently. `scripts/manifest_smoke_test.sh` (wired into test-with-snowflake.yml) isolates the binary in a driver-less dir with no env escape hatch, proves resolution FAILS without a manifest (negative control), then answers a real query through a manifest-resolved driver. Skips itself when secrets are absent so forks stay green.

## Verification

- Live end-to-end: negative control, resolution via the real dbc-written conda-prefix manifest, `ADBC_DRIVER_PATH`, and legacy `SNOWFLAKE_ADBC_DRIVER_PATH` precedence — all verified against a real Snowflake connection.
- `snowflake_basic_connectivity` and `snowflake_read_operations` green (bundled-driver path unchanged).
- clang-tidy clean on the new module (repo config, warnings-as-errors).

Closes #50.