### PR TITLE
Gate the connection-refusal test on SNOWFLAKE_ADBC_DRIVER_PATH

### DIFF
--- a/test/sql/snowflake_connection_failure.test
+++ b/test/sql/snowflake_connection_failure.test
@@ -9,9 +9,16 @@
 # waiting primitives in the pool), so a refusal can't hang a query either.
 #
 # This test needs no Snowflake credentials: the account is intentionally
-# nonexistent, so the driver's login request fails fast (HTTP 404).
+# nonexistent, so the driver's login request fails fast (HTTP 404). It DOES
+# need the ADBC driver present, or the refusal becomes a driver-not-found
+# error and the expected messages below never appear. require-env on the
+# explicit driver path keeps it running in this repo's CI (which always sets
+# it) while skipping driverless environments like the community-extensions
+# registry build, whose test runner has no driver installed.
 
 require snowflake
+
+require-env SNOWFLAKE_ADBC_DRIVER_PATH
 
 statement ok
 CREATE SECRET bad_sf (


### PR DESCRIPTION
The community-extensions registry build runs our SQL test suite with no ADBC driver installed, so the ATTACH refusal in `snowflake_connection_failure.test` surfaces as driver-not-found instead of "Failed to initialize connection" — this failed the 0.5.0 registry build (duckdb/community-extensions#2301, linux_amd64 test leg).

The test needs no credentials, but it does need the driver present to reach the login-refusal stage. `require-env SNOWFLAKE_ADBC_DRIVER_PATH` keeps it running in this repo's CI (which always sets the var in the test step) and skips driverless environments like the registry's test runner.

Test-only change; no shipped code affected.