### PR TITLE
Route LIST/EXPLAIN/CALL through the RESULT_SCAN re-target

### DIFF
--- a/src/include/snowflake_arrow_utils.hpp
+++ b/src/include/snowflake_arrow_utils.hpp
@@ -117,7 +117,7 @@ void SnowflakeExecuteAndCacheStream(SnowflakeArrowStreamFactory *factory, ArrowS
 // Execute factory->query on the leased connection (discarding its rows) and return
 // Snowflake's query id for it, read via LAST_QUERY_ID() on the same session — the
 // lease guarantees no other statement runs in between. Used by snowflake_query bind
-// to re-target row-returning metadata statements (SHOW/DESC) at
+// to re-target row-returning metadata statements (SHOW/DESC/LIST/EXPLAIN/CALL) at
 // TABLE(RESULT_SCAN('<id>')), which unlike the raw statement can be wrapped as a
 // projected subquery (issue #48).
 std::string SnowflakeExecuteAndGetQueryId(SnowflakeArrowStreamFactory *factory);

--- a/src/snowflake_arrow_utils.cpp
+++ b/src/snowflake_arrow_utils.cpp
@@ -470,8 +470,19 @@ static std::string ReadFirstRowUtf8(ArrowArrayStream &stream, const char *what) 
 }
 
 std::string SnowflakeExecuteAndGetQueryId(SnowflakeArrowStreamFactory *factory) {
+	// LAST_QUERY_ID() below is only correct if both statements run on the same
+	// exclusively-leased session with nothing in between. Capture the connection
+	// identity so a refactor that swaps or re-acquires the lease mid-flight fails
+	// loudly here instead of splicing a foreign query id into RESULT_SCAN.
+	auto *leased_connection = factory->lease->GetConnection();
+
 	// Run the statement itself; RESULT_SCAN only needs it executed server-side.
 	ExecuteOnLease(factory, factory->query, nullptr, nullptr, "metadata statement");
+
+	if (factory->lease->GetConnection() != leased_connection) {
+		throw InternalException("snowflake_query metadata path: connection changed between the statement and "
+		                        "LAST_QUERY_ID(); the query id would belong to a different session");
+	}
 
 	// Same session (exclusive lease), so LAST_QUERY_ID() is the statement above.
 	// The statement handle stays open until the stream is drained and released.

--- a/src/snowflake_scan.cpp
+++ b/src/snowflake_scan.cpp
@@ -65,8 +65,16 @@ static unique_ptr<FunctionData> SnowflakeScanBind(ClientContext &context, TableF
 	auto upper = StringUtil::Upper(trimmed);
 	bool is_select = StringUtil::StartsWith(upper, "SELECT") || StringUtil::StartsWith(upper, "WITH") ||
 	                 StringUtil::StartsWith(upper, "(");
-	// Row-returning metadata statements. DESC also covers DESCRIBE.
-	bool is_metadata_rows = StringUtil::StartsWith(upper, "SHOW") || StringUtil::StartsWith(upper, "DESC");
+	// Row-returning metadata statements, matched on the first keyword (not a raw
+	// prefix, so an unrelated statement starting with the same letters can't
+	// false-match). Every one of these returns rows but cannot be wrapped as a
+	// subquery, and every one is re-readable through RESULT_SCAN, so they all
+	// need the re-target below — issue #48 applied to LIST/EXPLAIN/CALL exactly
+	// as it did to SHOW/DESC.
+	auto first_token = upper.substr(0, upper.find_first_of(" \t\n\r("));
+	bool is_metadata_rows = first_token == "SHOW" || first_token == "DESC" || first_token == "DESCRIBE" ||
+	                        first_token == "LIST" || first_token == "LS" || first_token == "EXPLAIN" ||
+	                        first_token == "CALL";
 
 	if (is_select) {
 		// SELECT path: DuckDB's Arrow scanner prunes columns and reads the produced
@@ -80,7 +88,7 @@ static unique_ptr<FunctionData> SnowflakeScanBind(ClientContext &context, TableF
 		bind_data->projection_pushdown_enabled = true;
 		SnowflakeGetArrowSchemaViaQuery(bind_data->factory.get(), bind_data->schema_root.arrow_schema);
 	} else if (is_metadata_rows) {
-		// SHOW/DESC return rows but cannot be wrapped as a subquery, so the SELECT
+		// These return rows but cannot be wrapped as a subquery, so the SELECT
 		// path's projection wrap can't apply to the raw statement — and the cached
 		// full-width stream misaligns DuckDB's positional reads on non-prefix
 		// projections (issue #48; prefix projections only worked by accident).

--- a/test/sql/snowflake_query_resultscan_coverage.test
+++ b/test/sql/snowflake_query_resultscan_coverage.test
@@ -1,0 +1,78 @@
+# name: test/sql/snowflake_query_resultscan_coverage.test
+# description: Projected LIST/EXPLAIN/CALL through snowflake_query() route via RESULT_SCAN
+# group: [sql]
+
+#              Follow-up to issue #48: the RESULT_SCAN re-target originally covered only
+#              SHOW/DESC. LIST, EXPLAIN, and CALL also return rows that cannot be wrapped
+#              as a subquery; before this fix a non-prefix projection of their results
+#              misaligned DuckDB's positional Arrow reads (ArrowTypeInfo INTERNAL Error
+#              or silently wrong values).
+
+require snowflake
+
+require-env SNOWFLAKE_ACCOUNT
+
+require-env SNOWFLAKE_KEYPAIR_USER
+
+require-env SNOWFLAKE_PRIVATE_KEY_PATH
+
+require-env SNOWFLAKE_PRIVATE_KEY_PASSPHRASE
+
+require-env SNOWFLAKE_DATABASE
+
+statement ok
+LOAD snowflake;
+
+statement ok
+CREATE SECRET sf_rescan_secret (
+    TYPE snowflake,
+    ACCOUNT '${SNOWFLAKE_ACCOUNT}',
+    USER '${SNOWFLAKE_KEYPAIR_USER}',
+    AUTH_TYPE 'key_pair',
+    PRIVATE_KEY_FILE '${SNOWFLAKE_PRIVATE_KEY_PATH}',
+    PRIVATE_KEY_PASSWORD '${SNOWFLAKE_PRIVATE_KEY_PASSPHRASE}',
+    DATABASE '${SNOWFLAKE_DATABASE}',
+    WAREHOUSE 'COMPUTE_WH'
+);
+
+# Test 1: SELECT * over EXPLAIN (baseline - always worked)
+query I
+SELECT count(*) >= 1 FROM snowflake_query('EXPLAIN SELECT 1', 'sf_rescan_secret');
+----
+true
+
+# Test 2: non-prefix projection of EXPLAIN ("operation" and "id" are the 4th and
+# 2nd of ten columns). Before the fix: ArrowTypeInfo type mismatch (INTERNAL Error).
+query II
+SELECT count(*), count("id") FROM snowflake_query('EXPLAIN SELECT 1', 'sf_rescan_secret') WHERE "operation" = 'Result';
+----
+1	1
+
+# Fixtures for LIST and CALL (need a writable database)
+statement ok
+SELECT * FROM snowflake_query('CREATE OR REPLACE SCHEMA ${SNOWFLAKE_DATABASE}.RESULTSCAN_COV', 'sf_rescan_secret');
+
+statement ok
+SELECT * FROM snowflake_query('CREATE OR REPLACE STAGE ${SNOWFLAKE_DATABASE}.RESULTSCAN_COV.COV_STAGE', 'sf_rescan_secret');
+
+statement ok
+SELECT * FROM snowflake_query('COPY INTO @${SNOWFLAKE_DATABASE}.RESULTSCAN_COV.COV_STAGE/one.csv FROM (SELECT 1) FILE_FORMAT = (TYPE = CSV COMPRESSION = NONE) OVERWRITE = TRUE SINGLE = TRUE', 'sf_rescan_secret');
+
+# Test 3: non-prefix projection of LIST ("size" is the 2nd of four columns)
+query I
+SELECT count(*) FROM snowflake_query('LIST @${SNOWFLAKE_DATABASE}.RESULTSCAN_COV.COV_STAGE', 'sf_rescan_secret') WHERE "size" > 0;
+----
+1
+
+statement ok
+SELECT * FROM snowflake_query('CREATE OR REPLACE PROCEDURE ${SNOWFLAKE_DATABASE}.RESULTSCAN_COV.TWO_COL_PROC() RETURNS TABLE(A NUMBER, B VARCHAR) LANGUAGE SQL AS $$ DECLARE rs RESULTSET DEFAULT (SELECT 1 AS A, ''one'' AS B UNION ALL SELECT 2, ''two''); BEGIN RETURN TABLE(rs); END $$', 'sf_rescan_secret');
+
+# Test 4: non-prefix projection of CALL (B is the 2nd column of the returned table)
+query T
+SELECT B FROM snowflake_query('CALL ${SNOWFLAKE_DATABASE}.RESULTSCAN_COV.TWO_COL_PROC()', 'sf_rescan_secret') ORDER BY B;
+----
+one
+two
+
+statement ok
+SELECT * FROM snowflake_query('DROP SCHEMA ${SNOWFLAKE_DATABASE}.RESULTSCAN_COV CASCADE', 'sf_rescan_secret');

--- a/test/sql/snowflake_query_resultscan_coverage.test
+++ b/test/sql/snowflake_query_resultscan_coverage.test
@@ -1,12 +1,13 @@
 # name: test/sql/snowflake_query_resultscan_coverage.test
-# description: Projected LIST/EXPLAIN/CALL through snowflake_query() route via RESULT_SCAN
+# description: Projected EXPLAIN through snowflake_query() routes via RESULT_SCAN
 # group: [sql]
 
 #              Follow-up to issue #48: the RESULT_SCAN re-target originally covered only
-#              SHOW/DESC. LIST, EXPLAIN, and CALL also return rows that cannot be wrapped
-#              as a subquery; before this fix a non-prefix projection of their results
-#              misaligned DuckDB's positional Arrow reads (ArrowTypeInfo INTERNAL Error
-#              or silently wrong values).
+#              SHOW/DESC. EXPLAIN also returns rows that cannot be wrapped as a subquery;
+#              before this fix a non-prefix projection of its result misaligned DuckDB's
+#              positional Arrow reads (ArrowTypeInfo INTERNAL Error or silently wrong
+#              values). LIST and CALL need a writable database and are covered in
+#              snowflake_query_resultscan_write.test.
 
 require snowflake
 
@@ -47,32 +48,3 @@ query II
 SELECT count(*), count("id") FROM snowflake_query('EXPLAIN SELECT 1', 'sf_rescan_secret') WHERE "operation" = 'Result';
 ----
 1	1
-
-# Fixtures for LIST and CALL (need a writable database)
-statement ok
-SELECT * FROM snowflake_query('CREATE OR REPLACE SCHEMA ${SNOWFLAKE_DATABASE}.RESULTSCAN_COV', 'sf_rescan_secret');
-
-statement ok
-SELECT * FROM snowflake_query('CREATE OR REPLACE STAGE ${SNOWFLAKE_DATABASE}.RESULTSCAN_COV.COV_STAGE', 'sf_rescan_secret');
-
-statement ok
-SELECT * FROM snowflake_query('COPY INTO @${SNOWFLAKE_DATABASE}.RESULTSCAN_COV.COV_STAGE/one.csv FROM (SELECT 1) FILE_FORMAT = (TYPE = CSV COMPRESSION = NONE) OVERWRITE = TRUE SINGLE = TRUE', 'sf_rescan_secret');
-
-# Test 3: non-prefix projection of LIST ("size" is the 2nd of four columns)
-query I
-SELECT count(*) FROM snowflake_query('LIST @${SNOWFLAKE_DATABASE}.RESULTSCAN_COV.COV_STAGE', 'sf_rescan_secret') WHERE "size" > 0;
-----
-1
-
-statement ok
-SELECT * FROM snowflake_query('CREATE OR REPLACE PROCEDURE ${SNOWFLAKE_DATABASE}.RESULTSCAN_COV.TWO_COL_PROC() RETURNS TABLE(A NUMBER, B VARCHAR) LANGUAGE SQL AS $$ DECLARE rs RESULTSET DEFAULT (SELECT 1 AS A, ''one'' AS B UNION ALL SELECT 2, ''two''); BEGIN RETURN TABLE(rs); END $$', 'sf_rescan_secret');
-
-# Test 4: non-prefix projection of CALL (B is the 2nd column of the returned table)
-query T
-SELECT B FROM snowflake_query('CALL ${SNOWFLAKE_DATABASE}.RESULTSCAN_COV.TWO_COL_PROC()', 'sf_rescan_secret') ORDER BY B;
-----
-one
-two
-
-statement ok
-SELECT * FROM snowflake_query('DROP SCHEMA ${SNOWFLAKE_DATABASE}.RESULTSCAN_COV CASCADE', 'sf_rescan_secret');

--- a/test/sql/snowflake_query_resultscan_write.test
+++ b/test/sql/snowflake_query_resultscan_write.test
@@ -1,0 +1,64 @@
+# name: test/sql/snowflake_query_resultscan_write.test
+# description: Projected LIST/CALL through snowflake_query() route via RESULT_SCAN
+# group: [sql]
+
+#              Companion to snowflake_query_resultscan_coverage.test for the statements
+#              whose fixtures need write access: LIST (stage) and CALL (procedure).
+#              Writes to SNOWFLAKE_TEST_WRITE_DATABASE, the writable DB kept separate
+#              from SNOWFLAKE_DATABASE (the read-only sample source), same as the
+#              geometry and timestamp_ntz tests.
+
+require snowflake
+
+require-env SNOWFLAKE_ACCOUNT
+
+require-env SNOWFLAKE_USERNAME
+
+require-env SNOWFLAKE_PRIVATE_KEY_FILE
+
+require-env SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE
+
+require-env SNOWFLAKE_TEST_WRITE_DATABASE
+
+statement ok
+LOAD snowflake;
+
+statement ok
+CREATE SECRET sf_rescan_write_secret (
+    TYPE snowflake,
+    ACCOUNT '${SNOWFLAKE_ACCOUNT}',
+    USER '${SNOWFLAKE_USERNAME}',
+    AUTH_TYPE 'key_pair',
+    PRIVATE_KEY_FILE '${SNOWFLAKE_PRIVATE_KEY_FILE}',
+    PRIVATE_KEY_PASSWORD '${SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE}',
+    DATABASE '${SNOWFLAKE_TEST_WRITE_DATABASE}',
+    WAREHOUSE 'COMPUTE_WH'
+);
+
+statement ok
+SELECT * FROM snowflake_query('CREATE OR REPLACE SCHEMA ${SNOWFLAKE_TEST_WRITE_DATABASE}.RESULTSCAN_COV', 'sf_rescan_write_secret');
+
+statement ok
+SELECT * FROM snowflake_query('CREATE OR REPLACE STAGE ${SNOWFLAKE_TEST_WRITE_DATABASE}.RESULTSCAN_COV.COV_STAGE', 'sf_rescan_write_secret');
+
+statement ok
+SELECT * FROM snowflake_query('COPY INTO @${SNOWFLAKE_TEST_WRITE_DATABASE}.RESULTSCAN_COV.COV_STAGE/one.csv FROM (SELECT 1) FILE_FORMAT = (TYPE = CSV COMPRESSION = NONE) OVERWRITE = TRUE SINGLE = TRUE', 'sf_rescan_write_secret');
+
+# Test 1: non-prefix projection of LIST ("size" is the 2nd of four columns)
+query I
+SELECT count(*) FROM snowflake_query('LIST @${SNOWFLAKE_TEST_WRITE_DATABASE}.RESULTSCAN_COV.COV_STAGE', 'sf_rescan_write_secret') WHERE "size" > 0;
+----
+1
+
+statement ok
+SELECT * FROM snowflake_query('CREATE OR REPLACE PROCEDURE ${SNOWFLAKE_TEST_WRITE_DATABASE}.RESULTSCAN_COV.TWO_COL_PROC() RETURNS TABLE(A NUMBER, B VARCHAR) LANGUAGE SQL AS $$ DECLARE rs RESULTSET DEFAULT (SELECT 1 AS A, ''one'' AS B UNION ALL SELECT 2, ''two''); BEGIN RETURN TABLE(rs); END $$', 'sf_rescan_write_secret');
+
+# Test 2: non-prefix projection of CALL (B is the 2nd column of the returned table)
+query T
+SELECT B FROM snowflake_query('CALL ${SNOWFLAKE_TEST_WRITE_DATABASE}.RESULTSCAN_COV.TWO_COL_PROC()', 'sf_rescan_write_secret') ORDER BY B;
+----
+one
+two
+
+statement ok
+SELECT * FROM snowflake_query('DROP SCHEMA ${SNOWFLAKE_TEST_WRITE_DATABASE}.RESULTSCAN_COV CASCADE', 'sf_rescan_write_secret');


### PR DESCRIPTION
Closes #59.

The bind-time classifier in `snowflake_scan.cpp` only sent `SHOW`/`DESC` through the RESULT_SCAN re-target added for #48. `LIST`, `EXPLAIN`, and `CALL` fell through to the DDL/DML branch, which caches the full-width stream and ignores projection, so any non-prefix projection of their results misaligned DuckDB's positional Arrow reads: `ArrowTypeInfo` INTERNAL Error, or silently wrong values when the types happened to line up.

Changes:

- Classify row-returning metadata statements by first keyword (`SHOW`, `DESC`, `DESCRIBE`, `LIST`, `LS`, `EXPLAIN`, `CALL`) instead of a raw prefix match, and route them all through `TABLE(RESULT_SCAN('<query id>'))`.
- Guard the `LAST_QUERY_ID()` session-affinity invariant in `SnowflakeExecuteAndGetQueryId` with a connection-identity check. If a refactor ever runs the statement and the id read on different connections, we throw instead of splicing a foreign query id into RESULT_SCAN, which would silently serve another session's result set.
- New regression test `snowflake_query_resultscan_coverage.test`: projected EXPLAIN, projected LIST over a server-side-populated stage, and projected CALL of a table-returning procedure.

Verification against live Snowflake: the EXPLAIN projection reproduces the crash on published v0.5.0 and passes on this branch; LIST and CALL projections return the correct columns; existing `show_projection`, `query_projection`, and basic connectivity tests pass.
