### PR TITLE
Lint the whole src/ tree in tidy-check and fix the surfaced backlog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,18 @@ endif
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
 
+# Override extension-ci-tools' tidy-check: its file regex '$(PROJ_DIR)src/.*/'
+# requires a second path separator after src/, so the twelve translation units
+# directly in src/ were never linted - only src/storage/. This copy widens the
+# regex to the whole src/ tree. Make prints an "overriding recipe" warning for
+# this target on every run; that is expected and harmless. Drop the override if
+# the pattern is fixed upstream.
+tidy-check:
+	mkdir -p ./build/tidy
+	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_DEBUG_FLAGS) -DDISABLE_UNITY=1 -DCLANG_TIDY=1 -S $(DUCKDB_SRCDIR) -B build/tidy
+	cp duckdb/.clang-tidy build/tidy/.clang-tidy
+	cd build/tidy && python3 ../../duckdb/scripts/run-clang-tidy.py '$(PROJ_DIR)src/' -header-filter '$(PROJ_DIR)src/' -quiet ${TIDY_THREAD_PARAMETER} ${TIDY_BINARY_PARAMETER} ${TIDY_PERFORM_CHECKS}
+
 # Download pre-built ADBC driver if not present
 .PHONY: download-adbc
 download-adbc:

--- a/src/snowflake_arrow_utils.cpp
+++ b/src/snowflake_arrow_utils.cpp
@@ -322,8 +322,9 @@ void SnowflakeExecuteAndCacheStream(SnowflakeArrowStreamFactory *factory, ArrowS
 		std::string msg = "Failed to set query: ";
 		if (error.message) {
 			msg += error.message;
-			if (error.release)
+			if (error.release) {
 				error.release(&error);
+			}
 		}
 		throw IOException(msg);
 	}
@@ -336,8 +337,9 @@ void SnowflakeExecuteAndCacheStream(SnowflakeArrowStreamFactory *factory, ArrowS
 		std::string msg = "Failed to execute snowflake_query: ";
 		if (exec_error.message) {
 			msg += exec_error.message;
-			if (exec_error.release)
+			if (exec_error.release) {
 				exec_error.release(&exec_error);
+			}
 		}
 		if (IsAuthenticationError(msg)) {
 			auto &client_manager = snowflake::SnowflakeClientManager::GetInstance();

--- a/src/snowflake_client.cpp
+++ b/src/snowflake_client.cpp
@@ -141,7 +141,7 @@ void SnowflakeClient::InitializeDatabase(const SnowflakeConfig &config) {
 	// 2. Check environment variable (for custom locations)
 	const char *env_path = std::getenv("SNOWFLAKE_ADBC_DRIVER_PATH");
 	if (env_path) {
-		search_paths.push_back(env_path);
+		search_paths.emplace_back(env_path);
 	}
 
 	// 3. ADBC driver-manifest discovery (issue #50): snowflake.toml in the dirs

--- a/src/snowflake_query_builder.cpp
+++ b/src/snowflake_query_builder.cpp
@@ -209,7 +209,7 @@ unique_ptr<ParsedExpression> SnowflakeQueryBuilder::BuildWhereExpression(TableFi
 			                        column_names.size());
 		}
 
-		string column_name = column_names[column_idx];
+		const string &column_name = column_names[column_idx];
 		auto condition = TransformFilter(*filter, column_name);
 		// Note: TransformFilter returns nullptr for filters that should be skipped
 		// (e.g., uninitialized DYNAMIC_FILTER) These filters will be applied by

--- a/src/snowflake_secret_provider.cpp
+++ b/src/snowflake_secret_provider.cpp
@@ -201,7 +201,11 @@ void SnowflakeSecret::Serialize(Serializer &serializer) const {
 }
 
 //! Custom deserialization for Snowflake secrets
-unique_ptr<BaseSecret> SnowflakeSecret::Deserialize(Deserializer &deserializer, BaseSecret base_secret) {
+// By-value parameter is dictated by DuckDB's secret_deserializer_t typedef; a
+// const reference would not match the registered function-pointer type.
+unique_ptr<BaseSecret>
+SnowflakeSecret::Deserialize(Deserializer &deserializer,
+                             BaseSecret base_secret) { // NOLINT(performance-unnecessary-value-param)
 	auto result = make_uniq<SnowflakeSecret>(base_secret.GetScope(), base_secret.GetProvider(), base_secret.GetName());
 
 	// Deserialize the secret map


### PR DESCRIPTION
Closes #60.

extension-ci-tools' `tidy-check` passes the file regex `'$(PROJ_DIR)src/.*/'` to `run-clang-tidy.py`. The pattern requires a second path separator after `src/`, so CI has only ever linted `src/storage/` - the twelve translation units directly in `src/` (the extension core) were invisible to the tidy gate.

Changes:

- Override `tidy-check` in our Makefile after the extension-ci-tools include, widening the file regex and `-header-filter` to `'$(PROJ_DIR)src/'`. Make prints an "overriding recipe" warning on every invocation; expected, documented at the override, and droppable once the pattern is fixed upstream (follow-up PR to duckdb/extension-ci-tools).
- Fix the complete backlog the widened run surfaces, in the same PR so the tidy job stays green: braces around two single-statement ifs in `snowflake_arrow_utils.cpp`, `emplace_back` in `snowflake_client.cpp`, a const reference instead of a copy in `snowflake_query_builder.cpp`, and a justified NOLINT on `SnowflakeSecret::Deserialize` - its by-value `BaseSecret` parameter is dictated by DuckDB's `secret_deserializer_t` function-pointer typedef, so a const reference cannot match.

Verification: `make tidy-check` exits 0 locally with the widened regex (clang-tidy 21; this PR's Code Quality run is the check against CI's clang-tidy); release build and the basic connectivity suite pass, all five fixes behavior-neutral.
