### PR TITLE
Fix two projection-correctness bugs in snowflake_query()

### DIFF
--- a/src/snowflake_arrow_utils.cpp
+++ b/src/snowflake_arrow_utils.cpp
@@ -240,7 +240,8 @@ void SnowflakeGetArrowSchemaViaQuery(SnowflakeArrowStreamFactory *factory, Arrow
 	//     first data batch, so the tag is absent from the ExecuteSchema metadata.
 	//     A 1-row result lets the driver peek (a 0-row result cannot be peeked).
 	//   * Timestamps: ExecuteSchema mis-reports Snowflake TIMESTAMP units (issue #44).
-	std::string probe_query = "SELECT * FROM (" + factory->modified_query + ") AS __sf_schema_probe LIMIT 1";
+	// Newlines guard against a trailing line comment swallowing the closing paren.
+	std::string probe_query = "SELECT * FROM (\n" + factory->modified_query + "\n) AS __sf_schema_probe LIMIT 1";
 
 	AdbcError error;
 	std::memset(&error, 0, sizeof(error));
@@ -603,7 +604,9 @@ void SnowflakeArrowStreamFactory::UpdatePassthroughProjection(const vector<strin
 		}
 		cols += snowflake::QuoteSnowflakeIdentifier(projection[i]);
 	}
-	modified_query = "SELECT " + cols + " FROM (" + query + ") AS __sf_passthrough";
+	// The newlines matter: a trailing line comment in the user's query would
+	// otherwise swallow the closing paren and alias.
+	modified_query = "SELECT " + cols + " FROM (\n" + query + "\n) AS __sf_passthrough";
 	DPRINT("Passthrough projection applied:\n  Original: %s\n  Modified: %s\n", query.c_str(), modified_query.c_str());
 }
 

--- a/src/snowflake_scan.cpp
+++ b/src/snowflake_scan.cpp
@@ -139,8 +139,26 @@ static unique_ptr<FunctionData> SnowflakeScanBind(ClientContext &context, TableF
 		SnowflakeGetArrowSchemaViaQuery(bind_data->factory.get(), bind_data->schema_root.arrow_schema);
 	} else {
 		// DDL/DML path: execute now and cache the stream. ExecuteSchema would leave
-		// the ADBC driver unable to create a second statement (SIGSEGV at produce),
-		// and a status result has no projection to honor.
+		// the ADBC driver unable to create a second statement (SIGSEGV at produce).
+		//
+		// The cached stream is full width and cannot be re-projected, so DuckDB must
+		// not prune columns for this scan. With pruning on, DuckDB maps projected
+		// output positions onto Arrow children positionally, so a non-prefix
+		// projection reads the wrong column — silently when the types happen to
+		// match, which is the common case for multi-column DML results (projecting
+		// `output_bytes` off a COPY INTO returned `rows_unloaded`).
+		//
+		// Clearing projection_pushdown on the bind's *copy* of the TableFunction
+		// disables pruning for this statement only: the binder copies the function
+		// into the plan after bind returns, so the registered function is untouched
+		// and other snowflake_query() calls still push projections down. DuckDB then
+		// scans all columns and applies the projection above the scan.
+		//
+		// projection_pushdown_enabled stays false so DuckDB clears column_ids and
+		// maps output position -> Arrow child positionally. That identity map is
+		// only correct because the line above guarantees the scan is full width;
+		// the two settings must be changed together.
+		input.table_function.projection_pushdown = false;
 		bind_data->factory->projection_pushdown_enabled = false;
 		bind_data->projection_pushdown_enabled = false;
 		SnowflakeExecuteAndCacheStream(bind_data->factory.get(), bind_data->schema_root.arrow_schema);

--- a/src/snowflake_scan.cpp
+++ b/src/snowflake_scan.cpp
@@ -14,6 +14,39 @@
 namespace duckdb {
 namespace snowflake {
 
+// Return the query with leading whitespace and SQL comments removed, for
+// classification only — the statement we actually send keeps its comments, so
+// query tags from dbt and similar tools still reach Snowflake's query history.
+// Without this, a leading comment makes the first token "/*" or "--", the
+// statement misses its execution path, and a projected scan reads the wrong
+// columns (the #48/#59 failure mode, reachable from an ordinary SELECT).
+// Block comments do NOT nest in Snowflake: the first "*/" ends the comment
+// (verified — a nested-looking comment is a syntax error server-side), so the
+// scan here must terminate at the first "*/" to classify what Snowflake parses.
+static std::string StripLeadingCommentsForClassification(const std::string &sql) {
+	size_t i = 0;
+	while (i < sql.size()) {
+		if (std::isspace(static_cast<unsigned char>(sql[i]))) {
+			i++;
+		} else if (sql.compare(i, 2, "--") == 0) {
+			auto newline = sql.find('\n', i);
+			if (newline == std::string::npos) {
+				return ""; // comment runs to end of input: nothing to classify
+			}
+			i = newline + 1;
+		} else if (sql.compare(i, 2, "/*") == 0) {
+			auto close = sql.find("*/", i + 2);
+			if (close == std::string::npos) {
+				return ""; // unterminated comment: let Snowflake report the syntax error
+			}
+			i = close + 2;
+		} else {
+			break;
+		}
+	}
+	return sql.substr(i);
+}
+
 static unique_ptr<FunctionData> SnowflakeScanBind(ClientContext &context, TableFunctionBindInput &input,
                                                   vector<LogicalType> &return_types, vector<string> &names) {
 	DPRINT("SnowflakeScanBind invoked\n");
@@ -60,7 +93,7 @@ static unique_ptr<FunctionData> SnowflakeScanBind(ClientContext &context, TableF
 	// Determine whether the passthrough query is a row-returning SELECT (projectable)
 	// or a DDL/DML statement (CREATE/INSERT/...), which returns a status result and
 	// is never column-pruned.
-	auto trimmed = query;
+	auto trimmed = StripLeadingCommentsForClassification(query);
 	StringUtil::LTrim(trimmed);
 	auto upper = StringUtil::Upper(trimmed);
 	bool is_select = StringUtil::StartsWith(upper, "SELECT") || StringUtil::StartsWith(upper, "WITH") ||

--- a/test/sql/snowflake_query_comment_classification.test
+++ b/test/sql/snowflake_query_comment_classification.test
@@ -1,0 +1,90 @@
+# name: test/sql/snowflake_query_comment_classification.test
+# description: Commented statements still take the right snowflake_query() path
+# group: [sql]
+
+#              Follow-up to #48/#59. snowflake_query() picks its execution path from
+#              the first token of the user's SQL. A leading comment - which dbt, BI
+#              tools, and query routers routinely prepend - made the first token "/*"
+#              or "--", so even a plain SELECT missed the projected-subquery path and
+#              fell into the cached-full-width-stream path that ignores projection.
+#              DuckDB then read projected columns positionally off a full-width
+#              stream: ArrowTypeInfo type mismatch, or silently wrong values.
+#              A trailing line comment was a second hazard: the subquery wrap used to
+#              splice the query inline, so the comment swallowed the closing paren.
+
+require snowflake
+
+require-env SNOWFLAKE_ACCOUNT
+
+require-env SNOWFLAKE_KEYPAIR_USER
+
+require-env SNOWFLAKE_PRIVATE_KEY_PATH
+
+require-env SNOWFLAKE_PRIVATE_KEY_PASSPHRASE
+
+require-env SNOWFLAKE_DATABASE
+
+statement ok
+LOAD snowflake;
+
+statement ok
+CREATE SECRET sf_comment_secret (
+    TYPE snowflake,
+    ACCOUNT '${SNOWFLAKE_ACCOUNT}',
+    USER '${SNOWFLAKE_KEYPAIR_USER}',
+    AUTH_TYPE 'key_pair',
+    PRIVATE_KEY_FILE '${SNOWFLAKE_PRIVATE_KEY_PATH}',
+    PRIVATE_KEY_PASSWORD '${SNOWFLAKE_PRIVATE_KEY_PASSPHRASE}',
+    DATABASE '${SNOWFLAKE_DATABASE}',
+    WAREHOUSE 'COMPUTE_WH'
+);
+
+# Test 1: baseline - uncommented SELECT, non-prefix projection
+query T
+SELECT N_NAME FROM snowflake_query('SELECT N_NATIONKEY, N_NAME, N_REGIONKEY FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF1.NATION ORDER BY N_NATIONKEY LIMIT 2', 'sf_comment_secret');
+----
+ALGERIA
+ARGENTINA
+
+# Test 2: leading block comment (dbt query-tag shape). Before the fix: crash.
+query T
+SELECT N_NAME FROM snowflake_query('/* {"app":"dbt","node":"model.x"} */ SELECT N_NATIONKEY, N_NAME, N_REGIONKEY FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF1.NATION ORDER BY N_NATIONKEY LIMIT 2', 'sf_comment_secret');
+----
+ALGERIA
+ARGENTINA
+
+# Test 3: leading line comment
+query T
+SELECT N_NAME FROM snowflake_query('-- routed by proxy
+SELECT N_NATIONKEY, N_NAME, N_REGIONKEY FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF1.NATION ORDER BY N_NATIONKEY LIMIT 2', 'sf_comment_secret');
+----
+ALGERIA
+ARGENTINA
+
+# Test 4: several stacked comments of both kinds. Block comments do NOT nest in
+# Snowflake (the first */ closes them), so the stripper must not track depth.
+query T
+SELECT N_NAME FROM snowflake_query('/* one */ -- two
+/* three */ SELECT N_NATIONKEY, N_NAME FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF1.NATION ORDER BY N_NATIONKEY LIMIT 2', 'sf_comment_secret');
+----
+ALGERIA
+ARGENTINA
+
+# Test 5: trailing line comment must not swallow the subquery wrap's closing paren
+query T
+SELECT N_NAME FROM snowflake_query('SELECT N_NATIONKEY, N_NAME FROM SNOWFLAKE_SAMPLE_DATA.TPCH_SF1.NATION ORDER BY N_NATIONKEY LIMIT 2 -- trailing', 'sf_comment_secret');
+----
+ALGERIA
+ARGENTINA
+
+# Test 6: commented metadata statement still routes through RESULT_SCAN
+query I
+SELECT count(*) >= 1 FROM snowflake_query('/* c */ SHOW SCHEMAS IN DATABASE SNOWFLAKE_SAMPLE_DATA', 'sf_comment_secret');
+----
+true
+
+# Test 7: projected commented metadata statement returns the right column
+query I
+SELECT count(*) >= 1 FROM (SELECT "name" FROM snowflake_query('/* c */ SHOW SCHEMAS IN DATABASE SNOWFLAKE_SAMPLE_DATA', 'sf_comment_secret') WHERE "name" = 'INFORMATION_SCHEMA');
+----
+true

--- a/test/sql/snowflake_query_dml_projection.test
+++ b/test/sql/snowflake_query_dml_projection.test
@@ -1,0 +1,80 @@
+# name: test/sql/snowflake_query_dml_projection.test
+# description: Projected multi-column DML results through snowflake_query() read the right column
+# group: [sql]
+
+#              Follow-up to #48/#59. DDL/DML statements take the cached-full-width-stream
+#              path, which cannot re-project. DuckDB used to prune columns for that scan
+#              anyway and then map output positions onto Arrow children positionally, so
+#              projecting a multi-column DML result read the WRONG column - silently,
+#              because the columns share a type: `SELECT output_bytes` off a COPY INTO
+#              returned rows_unloaded (3 instead of 93). The bind now clears
+#              projection_pushdown on its own copy of the TableFunction so DuckDB scans
+#              full width and projects above the scan.
+#
+#              Byte counts are deterministic: three 30-character rows plus newlines = 93.
+
+require snowflake
+
+require-env SNOWFLAKE_ACCOUNT
+
+require-env SNOWFLAKE_USERNAME
+
+require-env SNOWFLAKE_PRIVATE_KEY_FILE
+
+require-env SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE
+
+require-env SNOWFLAKE_TEST_WRITE_DATABASE
+
+statement ok
+LOAD snowflake;
+
+statement ok
+CREATE SECRET sf_dml_proj_secret (
+    TYPE snowflake,
+    ACCOUNT '${SNOWFLAKE_ACCOUNT}',
+    USER '${SNOWFLAKE_USERNAME}',
+    AUTH_TYPE 'key_pair',
+    PRIVATE_KEY_FILE '${SNOWFLAKE_PRIVATE_KEY_FILE}',
+    PRIVATE_KEY_PASSWORD '${SNOWFLAKE_PRIVATE_KEY_PASSWORD_FILE}',
+    DATABASE '${SNOWFLAKE_TEST_WRITE_DATABASE}',
+    WAREHOUSE 'COMPUTE_WH'
+);
+
+statement ok
+SELECT * FROM snowflake_query('CREATE OR REPLACE SCHEMA ${SNOWFLAKE_TEST_WRITE_DATABASE}.DML_PROJ', 'sf_dml_proj_secret');
+
+statement ok
+SELECT * FROM snowflake_query('CREATE OR REPLACE STAGE ${SNOWFLAKE_TEST_WRITE_DATABASE}.DML_PROJ.STG', 'sf_dml_proj_secret');
+
+# Test 1: baseline - all three COPY INTO columns
+query III
+SELECT * FROM snowflake_query('COPY INTO @${SNOWFLAKE_TEST_WRITE_DATABASE}.DML_PROJ.STG/a.csv FROM (SELECT ''aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'' UNION ALL SELECT ''bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'' UNION ALL SELECT ''cccccccccccccccccccccccccccccc'') FILE_FORMAT = (TYPE = CSV COMPRESSION = NONE) OVERWRITE = TRUE SINGLE = TRUE', 'sf_dml_proj_secret');
+----
+3	93	93
+
+# Test 2: project the LAST column only. Before the fix this returned 3 (rows_unloaded).
+query I
+SELECT output_bytes FROM snowflake_query('COPY INTO @${SNOWFLAKE_TEST_WRITE_DATABASE}.DML_PROJ.STG/b.csv FROM (SELECT ''aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'' UNION ALL SELECT ''bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'' UNION ALL SELECT ''cccccccccccccccccccccccccccccc'') FILE_FORMAT = (TYPE = CSV COMPRESSION = NONE) OVERWRITE = TRUE SINGLE = TRUE', 'sf_dml_proj_secret');
+----
+93
+
+# Test 3: project a MIDDLE column only
+query I
+SELECT input_bytes FROM snowflake_query('COPY INTO @${SNOWFLAKE_TEST_WRITE_DATABASE}.DML_PROJ.STG/c.csv FROM (SELECT ''aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'' UNION ALL SELECT ''bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'' UNION ALL SELECT ''cccccccccccccccccccccccccccccc'') FILE_FORMAT = (TYPE = CSV COMPRESSION = NONE) OVERWRITE = TRUE SINGLE = TRUE', 'sf_dml_proj_secret');
+----
+93
+
+# Test 4: reordered projection of two columns
+query II
+SELECT output_bytes, rows_unloaded FROM snowflake_query('COPY INTO @${SNOWFLAKE_TEST_WRITE_DATABASE}.DML_PROJ.STG/d.csv FROM (SELECT ''aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'' UNION ALL SELECT ''bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'' UNION ALL SELECT ''cccccccccccccccccccccccccccccc'') FILE_FORMAT = (TYPE = CSV COMPRESSION = NONE) OVERWRITE = TRUE SINGLE = TRUE', 'sf_dml_proj_secret');
+----
+93	3
+
+# Test 5: single-column DDL status still works (must not regress)
+query T
+SELECT status FROM snowflake_query('CREATE OR REPLACE STAGE ${SNOWFLAKE_TEST_WRITE_DATABASE}.DML_PROJ.STG2', 'sf_dml_proj_secret');
+----
+Stage area STG2 successfully created.
+
+statement ok
+SELECT * FROM snowflake_query('DROP SCHEMA ${SNOWFLAKE_TEST_WRITE_DATABASE}.DML_PROJ CASCADE', 'sf_dml_proj_secret');


### PR DESCRIPTION
Two projection-correctness fixes in `snowflake_query()`, both reachable from ordinary queries in the published 0.5.1. Follow-up to #48 and #59, which were narrower symptoms of the same defect.

### 1. Statements were classified from the first token, so a leading comment broke everything

`SnowflakeScanBind` picks its execution path from the first token of the user's SQL. A leading comment makes that token `/*` or `--`, so even a plain `SELECT` missed the projected-subquery path and fell into the cached-full-width-stream path that ignores projection. DuckDB then reads projected columns positionally off a full-width stream:

```sql
SELECT N_NAME FROM snowflake_query(
  '/* {"app":"dbt","node":"model.x"} */ SELECT N_NATIONKEY, N_NAME, N_REGIONKEY FROM ... ', 'sf');
-- INTERNAL Error: Failed to cast ArrowTypeInfo, type mismatch (expected: STRING, got: DECIMAL)
```

dbt, Looker, and query routers prepend comments to nearly every statement, so this is not an edge case.

Fix: strip leading whitespace and comments **for classification only**. The statement sent to Snowflake keeps its comments, so query tags still reach query history. Block comments do **not** nest in Snowflake (verified — a nested-looking comment is a server-side syntax error), so the scan stops at the first `*/`.

Also: the subquery wrap and schema probe now place the user query on its own line, so a *trailing* line comment cannot swallow the closing paren.

### 2. Projected multi-column DML results returned the wrong column, silently

DDL/DML takes the cached-full-width-stream path, which cannot re-project, but DuckDB pruned columns for that scan anyway and mapped output positions onto Arrow children positionally:

```sql
SELECT output_bytes FROM snowflake_query('COPY INTO @stage FROM (...)', 'sf');
-- returned 3 (rows_unloaded) instead of 93 (output_bytes)
```

No error and no warning, because COPY INTO's three columns share a type.

Fix: clear `projection_pushdown` on the bind's **own copy** of the `TableFunction`, so DuckDB scans full width and applies the projection above the scan. The binder copies the function into the plan after bind returns, so the registered function is untouched and other calls still push projections down. This must be paired with `bind_data->projection_pushdown_enabled = false` (the positional identity map, correct only because the scan is now full width) — changing one without the other crashes with `Attempted to access index 1 within vector of size 1`. The code comment records that coupling.

Chosen over routing DDL/DML through `RESULT_SCAN`: that adds a round-trip to every statement and needs guards for `PUT`/`GET`/`BEGIN`/`COMMIT`, which have no result set — new failure modes on the catch-all branch. This approach is correct for every statement type, including ones not yet seen, and turns misclassification from a correctness bug into a fetch-more-than-needed inefficiency.

### Tests

- `test/sql/snowflake_query_comment_classification.test` — 7 cases: block/line/stacked comments, trailing comment, commented metadata statements
- `test/sql/snowflake_query_dml_projection.test` — 5 cases: last-column, middle-column, and reordered projections of `COPY INTO`, with deterministic byte counts, plus a single-column DDL control

Verified against live Snowflake with before/after repro scripts. Full regression suite green: `resultscan_coverage`, `resultscan_write`, `show_projection`, `query_projection`, `basic_connectivity`, `query_ddl`. `make tidy-check` exits 0.

### Known, not fixed here

On the cached path `has_cached_stream` flips false after the first produce, so a second produce would re-execute the DDL/DML statement. Deserves its own issue.
